### PR TITLE
foundations for free-standing rules

### DIFF
--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -556,11 +556,12 @@ def load_alert_rules_from_dir(
         relpath = os.path.relpath(os.path.dirname(path), dir_path)
 
         # Generate group name:
-        #  - prefix, from the relative path of the rule file;
         #  - name, from juju topology
+        #  - suffix, from the relative path of the rule file;
         return (
+            f"{topology.identifier}_"
             f"{'' if relpath == '.' else relpath.replace(os.path.sep, '_') + '_'}"
-            f"{topology.identifier}_alerts"
+            "alerts"
         )
 
     invalid_files = []

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -458,7 +458,7 @@ class JujuTopology:
         )
 
     @property
-    def promql_labels(self) -> str:
+    def logql_labels(self) -> str:
         """Format the topology information into a verbose string."""
         return 'juju_model="{}", juju_model_uuid="{}", juju_application="{}"'.format(
             self.model, self.model_uuid, self.application
@@ -471,7 +471,7 @@ class JujuTopology:
             as_dict["model_uuid"] = self.short_model_uuid
         return as_dict
 
-    def as_dict_with_promql_labels(self):
+    def as_dict_with_logql_labels(self):
         """Format the topology information into a dict with keys having 'juju_' as prefix."""
         return {
             "juju_model": self.model,
@@ -482,7 +482,7 @@ class JujuTopology:
 
     def render(self, template: str):
         """Render a juju-topology template string with topology info."""
-        return template.replace("%%juju_topology%%", self.promql_labels)
+        return template.replace("%%juju_topology%%", self.logql_labels)
 
 
 def load_alert_rule_from_file(
@@ -509,7 +509,7 @@ def load_alert_rule_from_file(
             # add "juju_" topology labels
             if "labels" not in rule:
                 rule["labels"] = {}
-            rule["labels"].update(topology.as_dict_with_promql_labels())
+            rule["labels"].update(topology.as_dict_with_logql_labels())
 
             # insert juju topology filters into a Loki alert rule
             rule["expr"] = topology.render(rule["expr"])
@@ -952,7 +952,7 @@ class LokiPushApiConsumer(RelationManagerBase):
             topology labels.
         """
         labels = rule.get("labels", {})
-        labels.update(self.topology.as_dict_with_promql_labels())
+        labels.update(self.topology.as_dict_with_logql_labels())
         rule["labels"] = labels
         return rule
 

--- a/tests/sample_rule_files/free-standing/alerting.rule
+++ b/tests/sample_rule_files/free-standing/alerting.rule
@@ -1,0 +1,23 @@
+groups:
+  - name: should_fire
+    rules:
+      - alert: HighPercentageError
+        expr: |
+          sum(rate({app="foo", env="production"} |= "error" [5m])) by (job)
+            /
+          sum(rate({app="foo", env="production"}[5m])) by (job)
+            > 0.05
+        for: 10m
+        labels:
+            severity: page
+        annotations:
+            summary: High request latency
+  - name: credentials_leak
+    rules:
+      - alert: http-credentials-leaked
+        annotations:
+          message: "{{ $labels.job }} is leaking http basic auth credentials."
+        expr: 'sum by (cluster, job, pod) (count_over_time({namespace="prod"} |~ "http(s?)://(\\w+):(\\w+)@" [5m]) > 0)'
+        for: 10m
+        labels:
+          severity: critical

--- a/tests/sample_rule_files/free-standing/recording.rule
+++ b/tests/sample_rule_files/free-standing/recording.rule
@@ -1,0 +1,10 @@
+name: NginxRules
+interval: 1m
+rules:
+  - record: nginx:requests:rate1m
+    expr: |
+      sum(
+        rate({container="nginx"}[1m])
+      )
+    labels:
+      cluster: "us-central1"

--- a/tests/sample_rule_files/with_topology/alerting.rule
+++ b/tests/sample_rule_files/with_topology/alerting.rule
@@ -1,0 +1,11 @@
+alert: HighPercentageError_topo
+expr: |
+  sum(rate({app="foo", env="production", %%juju_topology%%} |= "error" [5m])) by (job)
+    /
+  sum(rate({app="foo", env="production", %%juju_topology%%}[5m])) by (job)
+    > 0.05
+for: 10m
+labels:
+    severity: page
+annotations:
+    summary: High request latency

--- a/tests/sample_rule_files/with_topology/alerting2.rule
+++ b/tests/sample_rule_files/with_topology/alerting2.rule
@@ -1,0 +1,7 @@
+alert: http-credentials-leaked_topo
+annotations:
+  message: "{{ $labels.job }} is leaking http basic auth credentials."
+expr: 'sum by (cluster, job, pod) (count_over_time({namespace="prod", %%juju_topology%%} |~ "http(s?)://(\\w+):(\\w+)@" [5m]) > 0)'
+for: 10m
+labels:
+  severity: critical

--- a/tests/sample_rule_files/with_topology/recording.rule
+++ b/tests/sample_rule_files/with_topology/recording.rule
@@ -1,0 +1,7 @@
+record: nginx:requests:rate1m
+expr: |
+  sum(
+    rate({container="nginx", %%juju_topology%%}[1m])
+  )
+labels:
+  cluster: "us-central1"

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -114,12 +114,6 @@ class TestLokiPushApiConsumer(unittest.TestCase):
         )
         self.assertEqual(self.harness.charm.loki_consumer._stored.loki_push_api, loki_push_api)
 
-    def test__label_alert_expression(self):
-        labeled_alert = self.harness.charm.loki_consumer._label_alert_expression(ONE_RULE.copy())
-        self.assertTrue("juju_model" in labeled_alert["expr"])
-        self.assertTrue("juju_model_uuid" in labeled_alert["expr"])
-        self.assertTrue("juju_application" in labeled_alert["expr"])
-
     def test__label_alert_topology(self):
         labeled_alert_topology = self.harness.charm.loki_consumer._label_alert_topology(
             ONE_RULE.copy()
@@ -129,16 +123,16 @@ class TestLokiPushApiConsumer(unittest.TestCase):
         self.assertTrue("juju_application" in labeled_alert_topology["labels"])
 
     def test__is_valid_rule(self):
-        self.assertTrue(_is_valid_rule(ONE_RULE.copy()))
+        self.assertTrue(_is_valid_rule(ONE_RULE.copy(), allow_free_standing=False))
 
         rule_1 = ONE_RULE.copy()
         del rule_1["alert"]
-        self.assertFalse(_is_valid_rule(rule_1))
+        self.assertFalse(_is_valid_rule(rule_1, allow_free_standing=False))
 
         rule_2 = ONE_RULE.copy()
         del rule_2["expr"]
-        self.assertFalse(_is_valid_rule(rule_2))
+        self.assertFalse(_is_valid_rule(rule_2, allow_free_standing=False))
 
         rule_3 = ONE_RULE.copy()
         rule_3["expr"] = "Missing Juju topology placeholder"
-        self.assertFalse(_is_valid_rule(rule_3))
+        self.assertFalse(_is_valid_rule(rule_3, allow_free_standing=False))

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -7,7 +7,11 @@ import unittest
 from pathlib import Path
 from unittest.mock import PropertyMock, patch
 
-from charms.loki_k8s.v0.loki_push_api import AlertRuleError, LokiPushApiConsumer
+from charms.loki_k8s.v0.loki_push_api import (
+    AlertRuleError,
+    LokiPushApiConsumer,
+    _validate_alert_rule,
+)
 from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.testing import Harness
@@ -131,21 +135,19 @@ class TestLokiPushApiConsumer(unittest.TestCase):
 
     def test__validate_alert_rule(self):
         thefile = Path("rulefile.rule")
-        self.assertIsNone(
-            self.harness.charm.loki_consumer._validate_alert_rule(ONE_RULE.copy(), thefile)
-        )
+        self.assertIsNone(_validate_alert_rule(ONE_RULE.copy(), thefile))
 
         with self.assertRaises(AlertRuleError):
             rule_1 = ONE_RULE.copy()
             del rule_1["alert"]
-            self.harness.charm.loki_consumer._validate_alert_rule(rule_1, thefile)
+            _validate_alert_rule(rule_1, thefile)
 
         with self.assertRaises(AlertRuleError):
             rule_2 = ONE_RULE.copy()
             del rule_2["expr"]
-            self.harness.charm.loki_consumer._validate_alert_rule(rule_2, thefile)
+            _validate_alert_rule(rule_2, thefile)
 
         with self.assertRaises(AlertRuleError):
             rule_3 = ONE_RULE.copy()
             rule_3["expr"] = "Missing Juju topology placeholder"
-            self.harness.charm.loki_consumer._validate_alert_rule(rule_3, thefile)
+            _validate_alert_rule(rule_3, thefile)

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -15,6 +15,7 @@ METADATA = {
     "model": "consumer-model",
     "model_uuid": "qwerty-1234",
     "application": "promtail",
+    "charm_name": "charm-k8s",
 }
 
 ALERT_RULES = {


### PR DESCRIPTION
This PR adds the necessary functionality needed by [lma-rules-operator](https://github.com/canonical/lma-rules-operator) to forward free standing rules.
Similar changes have been [made to prometheus-operator](https://github.com/canonical/prometheus-operator/pull/149).

- [x] add JujuTopology class
- [x] add generic load_alert_rules_from_dir