### PR TITLE
push full config instead of pulling and updating

### DIFF
--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -272,10 +272,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
-
-# Alert rules directory in workload container
-RULES_DIR = "/loki/rules"
+LIBPATCH = 5
 
 logger = logging.getLogger(__name__)
 
@@ -662,7 +659,9 @@ class LoggingEvents(ObjectEvents):
 class LokiPushApiProvider(RelationManagerBase):
     """A LokiPushApiProvider class."""
 
-    def __init__(self, charm, relation_name: str = DEFAULT_RELATION_NAME):
+    def __init__(
+        self, charm, relation_name: str = DEFAULT_RELATION_NAME, *, rules_dir="/loki/rules"
+    ):
         """A Loki service provider.
 
         Args:
@@ -691,6 +690,11 @@ class LokiPushApiProvider(RelationManagerBase):
         super().__init__(charm, relation_name)
         self.charm = charm
         self._relation_name = relation_name
+
+        # If Loki is run in single-tenant mode, all the chunks are put in a folder named fake
+        # https://grafana.com/docs/loki/latest/operations/storage/filesystem/
+        self._rules_dir = os.path.join(rules_dir, "fake")
+
         self.container = self.charm.unit.get_container("loki")
         events = self.charm.on[relation_name]
         self.framework.observe(events.relation_changed, self._on_logging_relation_changed)
@@ -747,16 +751,16 @@ class LokiPushApiProvider(RelationManagerBase):
         return ""
 
     def _remove_alert_rules_files(self, container) -> None:
-        """Remove alert rules files from worload container RULES_DIR.
+        """Remove alert rules files from workload container.
 
         Args:
             container: Container which has alert rules files to be deleted
         """
-        container.remove_path(RULES_DIR, recursive=True)
+        container.remove_path(self._rules_dir, recursive=True)
         logger.debug("Previous Alert rules files deleted")
         # Since container.remove_path deletes the directory itself with its files
         # we should create it again.
-        os.makedirs(RULES_DIR, exist_ok=True)
+        os.makedirs(self._rules_dir, exist_ok=True)
 
     def _generate_alert_rules_files(self, container) -> None:
         """Generate and upload alert rules files.
@@ -769,7 +773,7 @@ class LokiPushApiProvider(RelationManagerBase):
                 JujuTopology.from_relation_data(alert_rules),
                 rel_id,
             )
-            path = os.path.join(RULES_DIR, filename)
+            path = os.path.join(self._rules_dir, filename)
             rules = yaml.dump({"groups": alert_rules["groups"]})
             container.push(path, rules, make_dirs=True)
             logger.debug("Updated alert rules file %s", filename)

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -691,9 +691,11 @@ class LokiPushApiProvider(RelationManagerBase):
         self.charm = charm
         self._relation_name = relation_name
 
-        # If Loki is run in single-tenant mode, all the chunks are put in a folder named fake
+        # If Loki is run in single-tenant mode, all the chunks are put in a folder named "fake"
         # https://grafana.com/docs/loki/latest/operations/storage/filesystem/
-        self._rules_dir = os.path.join(rules_dir, "fake")
+        # https://grafana.com/docs/loki/latest/rules/#ruler-storage
+        tenant_id = "fake"
+        self._rules_dir = os.path.join(rules_dir, tenant_id)
 
         self.container = self.charm.unit.get_container("loki")
         events = self.charm.on[relation_name]

--- a/src/charm.py
+++ b/src/charm.py
@@ -105,9 +105,10 @@ class LokiOperatorCharm(CharmBase):
 
         try:
             if yaml.safe_load(self._stored.config) != config:
-                self._container.push(LOKI_CONFIG, config)
+                config_as_yaml = yaml.safe_dump(config)
+                self._container.push(LOKI_CONFIG, config_as_yaml)
                 logger.info("Pushed new configuration")
-                self._stored.config = yaml.dump(config)
+                self._stored.config = config_as_yaml
                 restart = True
         except (ProtocolError, PathError) as e:
             self.unit.status = BlockedStatus(str(e))

--- a/src/charm.py
+++ b/src/charm.py
@@ -13,6 +13,8 @@ develop a new k8s charm using the Operator Framework:
 """
 
 import logging
+import os
+import textwrap
 
 import yaml
 from charms.alertmanager_k8s.v0.alertmanager_dispatch import AlertmanagerConsumer
@@ -27,7 +29,10 @@ from ops.pebble import PathError, ProtocolError
 from kubernetes_service import K8sServicePatch, PatchFailed
 from loki_server import LokiServer, LokiServerError, LokiServerNotReadyError
 
+# Paths in workload container
 LOKI_CONFIG = "/etc/loki/local-config.yaml"
+LOKI_DIR = "/loki"
+RULES_DIR = os.path.join(LOKI_DIR, "rules")
 
 logger = logging.getLogger(__name__)
 
@@ -100,9 +105,9 @@ class LokiOperatorCharm(CharmBase):
 
         try:
             if yaml.safe_load(self._stored.config) != config:
-                self._stored.config = yaml.dump(config)
-                self._container.push(LOKI_CONFIG, self._stored.config)
+                self._container.push(LOKI_CONFIG, config)
                 logger.info("Pushed new configuration")
+                self._stored.config = yaml.dump(config)
                 restart = True
         except (ProtocolError, PathError) as e:
             self.unit.status = BlockedStatus(str(e))
@@ -123,7 +128,7 @@ class LokiOperatorCharm(CharmBase):
             a sting consisting of Loki command and associated
             command line options.
         """
-        return f"/usr/bin/loki -target=all -config.file={LOKI_CONFIG}"
+        return f"/usr/bin/loki -config.file={LOKI_CONFIG}"
 
     @property
     def _build_pebble_layer(self):
@@ -194,15 +199,47 @@ class LokiOperatorCharm(CharmBase):
     def _loki_config(self) -> dict:
         """Construct Loki configuration.
 
-        Returns:
-            Loki config in a dictionary
-        """
-        raw_config = self._container.pull(LOKI_CONFIG).read()
-        config = yaml.safe_load(raw_config)
-        alerting_config = self._alerting_config()
-        config["ruler"]["alertmanager_url"] = alerting_config
+        Some minimal configuration is required for Loki to start, including: storage paths, schema,
+        ring.
 
-        return config
+        Returns:
+            Dictionary representation of the Loki YAML config
+        """
+        config = textwrap.dedent(
+            f"""
+            target: all
+            auth_enabled: false
+
+            server:
+              http_listen_port: {self._port}
+
+            common:
+              path_prefix: {LOKI_DIR}
+              storage:
+                filesystem:
+                  chunks_directory: {os.path.join(LOKI_DIR, "chunks")}
+                  rules_directory: {RULES_DIR}
+              replication_factor: 1
+              ring:
+                instance_addr: {self.loki_provider.unit_ip or ""}
+                kvstore:
+                  store: inmemory
+
+            schema_config:
+              configs:
+                - from: 2020-10-24
+                  store: boltdb-shipper
+                  object_store: filesystem
+                  schema: v11
+                  index:
+                    prefix: index_
+                    period: 24h
+
+            ruler:
+              alertmanager_url: {self._alerting_config()}
+        """
+        )
+        return yaml.safe_load(config)
 
 
 if __name__ == "__main__":

--- a/src/charm.py
+++ b/src/charm.py
@@ -221,7 +221,7 @@ class LokiOperatorCharm(CharmBase):
                   rules_directory: {RULES_DIR}
               replication_factor: 1
               ring:
-                instance_addr: {self.loki_provider.unit_ip or ""}
+                instance_addr: {self.loki_provider.unit_ip if self.loki_provider else ""}
                 kvstore:
                   store: inmemory
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 [tox]
 skipsdist=True
 skip_missing_interpreters = True
-envlist = lint, unit
+envlist = lint, static, unit
 
 [vars]
 src_path = {toxinidir}/src/

--- a/tox.ini
+++ b/tox.ini
@@ -82,7 +82,8 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    #git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
 commands =
@@ -104,7 +105,7 @@ commands =
     # run pytest on the integration tests of the lma bundle, but override loki with path to
     # this source dir
     pytest -v --tb native --log-cli-level=INFO -s --loki={toxinidir} {posargs} {[testenv:integration-lma]lma_bundle_dir}/tests/integration
-    
+
 [testenv:check]
 depends =
     lint


### PR DESCRIPTION
This PR proposes to:
1. Provide the minimal loki config explicitly, instead of pulling the one that is already in the container and updating it.
2. Have the rules dir passed to loki lib from the charm.
3. Add the "fake" subdir to the rules dir ([ref](https://grafana.com/docs/loki/latest/operations/storage/filesystem/)).
4. Update `_stored.config` only after `push` succeeds.