### PR TITLE
fix rules file path + upkeep

### DIFF
--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -674,6 +674,8 @@ class LokiPushApiProvider(RelationManagerBase):
                 deploying your charm will have a consistent experience with all
                 other charms that consume metrics endpoints.
 
+            rules_dir: path in workload container where rule files are to be stored.
+
         Raises:
             RelationNotFoundError: If there is no relation in the charm's metadata.yaml
                 with the same name as provided via `relation_name` argument.

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -272,7 +272,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 logger = logging.getLogger(__name__)
 

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -690,14 +690,17 @@ class LokiPushApiProvider(RelationManagerBase):
         super().__init__(charm, relation_name)
         self.charm = charm
         self._relation_name = relation_name
+        self.container = self.charm.unit.get_container("loki")
 
         # If Loki is run in single-tenant mode, all the chunks are put in a folder named "fake"
         # https://grafana.com/docs/loki/latest/operations/storage/filesystem/
         # https://grafana.com/docs/loki/latest/rules/#ruler-storage
         tenant_id = "fake"
         self._rules_dir = os.path.join(rules_dir, tenant_id)
+        # create tenant dir so that the /loki/api/v1/rules endpoint returns "no rule groups found"
+        # instead of "unable to read rule dir /loki/rules/fake: no such file or directory"
+        self.container.make_dir(self._rules_dir, make_parents=True)
 
-        self.container = self.charm.unit.get_container("loki")
         events = self.charm.on[relation_name]
         self.framework.observe(events.relation_changed, self._on_logging_relation_changed)
         self.framework.observe(events.relation_departed, self._on_logging_relation_departed)
@@ -772,7 +775,7 @@ class LokiPushApiProvider(RelationManagerBase):
         """
         for rel_id, alert_rules in self.alerts().items():
             filename = "{}_rel_{}_alert.rules".format(
-                JujuTopology.from_relation_data(alert_rules),
+                JujuTopology.from_relation_data(alert_rules).identifier,
                 rel_id,
             )
             path = os.path.join(self._rules_dir, filename)

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -692,7 +692,7 @@ class LokiPushApiProvider(RelationManagerBase):
         super().__init__(charm, relation_name)
         self.charm = charm
         self._relation_name = relation_name
-        self.container = self.charm.unit.get_container("loki")
+        self.container = self.charm._container
 
         # If Loki is run in single-tenant mode, all the chunks are put in a folder named "fake"
         # https://grafana.com/docs/loki/latest/operations/storage/filesystem/

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -52,4 +52,4 @@ resources:
   loki-image:
     type: oci-image
     description: OCI image
-    upstream-source: grafana/loki
+    upstream-source: grafana/loki:2.4.1

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -135,8 +135,9 @@ class TestCharm(unittest.TestCase):
         self.harness.update_config(yaml.safe_load(LOKI_CONFIG))
         self.assertIsInstance(self.harness.charm.unit.status, ActiveStatus)
 
+    @patch("ops.testing._TestingPebbleClient.make_dir")
     @patch("loki_server.LokiServer.version", new_callable=PropertyMock)
-    def test__provide_loki(self, mock_version):
+    def test__provide_loki(self, mock_version, *unused):
         mock_version.return_value = "3.14159"
 
         with self.assertLogs(level="DEBUG") as logger:
@@ -158,8 +159,9 @@ class TestCharm(unittest.TestCase):
         self.harness.charm._provide_loki()
         self.assertIsInstance(self.harness.charm.unit.status, BlockedStatus)
 
+    @patch("ops.testing._TestingPebbleClient.make_dir")
     @patch("loki_server.LokiServer.version", new_callable=PropertyMock)
-    def test__loki_config(self, mock_version):
+    def test__loki_config(self, mock_version, *unused):
         mock_version.return_value = "3.14159"
 
         with self.assertLogs(level="DEBUG") as logger:

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -69,6 +69,14 @@ class FakeLokiCharm(CharmBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args)
         self._port = 3100
+        self._container = type(
+            "FakeContainer",
+            (object,),
+            {
+                "make_dir": lambda *a, **kw: None,
+                "remove_path": lambda *a, **kw: None,
+            },
+        )
         with patch("ops.testing._TestingPebbleClient.make_dir"):
             self.loki_provider = LokiPushApiProvider(self, "logging")
 


### PR DESCRIPTION
This is a bugfix + upkeep PR:
- bugfix: add missing `.identifier` to rules filename. Before this change, filename was e.g. `JujuTopology(model='lma', model_uuid='ea95a2e', application='lma-rules-k8s', charm_name='lma-rules-k8s')_rel_6_alert.rules`. Bug introduced in my previous PR.
- add version tag to loki image
- create "tenant" dir and patch unittests that end up calling pebble's make_dir, until https://github.com/canonical/operator/pull/645 is merged.