### PR TITLE
Promtail binary is obtained from an attached resource or download it

### DIFF
--- a/lib/charms/loki_k8s/v0/log_proxy.py
+++ b/lib/charms/loki_k8s/v0/log_proxy.py
@@ -167,7 +167,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 PROMTAIL_BINARY_ZIP_URL = (
     "https://github.com/grafana/loki/releases/download/v2.4.1/promtail-linux-amd64.zip"

--- a/lib/charms/loki_k8s/v0/log_proxy.py
+++ b/lib/charms/loki_k8s/v0/log_proxy.py
@@ -98,7 +98,7 @@ resources:
 And the charm should be deployed this way:
 
 ```
-juju deploy ./you_charm.charm --resource promtail-bin=/tmp/promtail-linux-amd64
+juju deploy ./your_charm.charm --resource promtail-bin=/tmp/promtail-linux-amd64
 ```
 
 The object can raise a `PromtailDigestError` when:

--- a/lib/charms/loki_k8s/v0/log_proxy.py
+++ b/lib/charms/loki_k8s/v0/log_proxy.py
@@ -356,7 +356,7 @@ class LogProxyConsumer(RelationManagerBase):
     def _push_binary_to_workload(self, resource_path=BINARY_PATH) -> None:
         with open(resource_path, "rb") as f:
             self._container.push(WORKLOAD_BINARY_PATH, f, permissions=0o755, make_dirs=True)
-            logger.debug("Promtail binary file has been pushed to workload container.")
+            logger.debug("The promtail binary file has been pushed to the workload container.")
 
     def _is_promtail_attached(self) -> bool:
         """Checks whether Promtail binary is attached to the charm or not.

--- a/lib/charms/loki_k8s/v0/log_proxy.py
+++ b/lib/charms/loki_k8s/v0/log_proxy.py
@@ -364,7 +364,7 @@ class LogProxyConsumer(RelationManagerBase):
         with open(resource_path, "rb") as f:
             self._container.push(WORKLOAD_BINARY_PATH, f, permissions=0o755, make_dirs=True)
 
-        logger.debug("Promtail binary file has been obtained from an attached resource.")
+        logger.info("Promtail binary file has been obtained from an attached resource.")
         return True
 
     def _promtail_must_be_downloaded(self) -> bool:

--- a/lib/charms/loki_k8s/v0/log_proxy.py
+++ b/lib/charms/loki_k8s/v0/log_proxy.py
@@ -81,9 +81,10 @@ Once the library is implemented in a charmed operator and a relation is establis
 the charm that implements the `loki_push_api` interface, the library will inject a
 Pebble layer that runs Promtail in the workload container to send logs.
 
-The defaul behaivour is that Promtail binary that is injected into the workload container
+The default behaivour is that Promtail binary that is injected into the workload container
 is downloaded from internet, but in some scenarios workload containers cannot reach internet.
-In this situation Promtail binary must be uploaded to charmhub (Follow the instructions: https://juju.is/docs/sdk/publishing-resources)
+In this situation Promtail binary must be uploaded to charmhub (Follow the instructions:
+https://juju.is/docs/sdk/publishing-resources)
 and the following section added to `resources` section in metadata.yaml
 
 ```yaml

--- a/lib/charms/loki_k8s/v0/log_proxy.py
+++ b/lib/charms/loki_k8s/v0/log_proxy.py
@@ -83,9 +83,7 @@ Pebble layer that runs Promtail in the workload container to send logs.
 
 The default behaivour is that Promtail binary that is injected into the workload container
 is downloaded from internet, but in some scenarios workload containers cannot reach internet.
-In this situation Promtail binary must be uploaded to charmhub (Follow the instructions:
-https://juju.is/docs/sdk/publishing-resources)
-and the following section added to `resources` section in metadata.yaml
+In this situation the following section should be added to `resources` section in metadata.yaml
 
 ```yaml
 resources:
@@ -95,6 +93,11 @@ resources:
       filename: promtail-linux-amd64
 ```
 
+And the charm should be deployed this way:
+
+```
+juju deploy ./you_charm.charm --resource promtail-bin=/tmp/promtail-linux-amd64
+```
 
 The object can raise a `PromtailDigestError` when:
 

--- a/lib/charms/loki_k8s/v0/log_proxy.py
+++ b/lib/charms/loki_k8s/v0/log_proxy.py
@@ -426,7 +426,7 @@ class LogProxyConsumer(RelationManagerBase):
         return True if Path(BINARY_PATH).is_file() else False
 
     def _download_and_push_promtail_to_workload(self, event) -> None:
-        """Downloads Promtail zip file and push binary to workload."""
+        """Downloads a Promtail zip file and pushes the binary to the workload."""
         url = json.loads(event.relation.data[event.unit].get("data"))["promtail_binary_zip_url"]
 
         with urlopen(url) as r:

--- a/lib/charms/loki_k8s/v0/log_proxy.py
+++ b/lib/charms/loki_k8s/v0/log_proxy.py
@@ -83,7 +83,7 @@ Pebble layer that runs Promtail in the workload container to send logs.
 
 The default behaivour is that Promtail binary that is injected into the workload container
 is downloaded from internet, but in some scenarios workload containers cannot reach internet.
-To enable people operating in these situations, the following section should be added to the 
+To enable people operating in these situations, the following section should be added to the
 `resources` section of your charm's `metadata.yaml`, which will allow operators to attach a binary
 at runtime should they need, rather than rely on fetching from the internet.
 

--- a/lib/charms/loki_k8s/v0/log_proxy.py
+++ b/lib/charms/loki_k8s/v0/log_proxy.py
@@ -97,7 +97,9 @@ resources:
 And the charm should be deployed this way:
 
 ```
-juju deploy ./your_charm.charm --resource promtail-bin=/tmp/promtail-linux-amd64
+juju deploy \
+    ./your_charm.charm \
+    --resource promtail-bin=/tmp/promtail-linux-amd64
 ```
 
 The object can raise a `PromtailDigestError` when:

--- a/lib/charms/loki_k8s/v0/log_proxy.py
+++ b/lib/charms/loki_k8s/v0/log_proxy.py
@@ -94,7 +94,7 @@ resources:
       filename: promtail-linux-amd64
 ```
 
-And the charm should be deployed this way:
+Which would then allow operators to deploy the charm this way:
 
 ```
 juju deploy \

--- a/lib/charms/loki_k8s/v0/log_proxy.py
+++ b/lib/charms/loki_k8s/v0/log_proxy.py
@@ -81,11 +81,10 @@ Once the library is implemented in a charmed operator and a relation is establis
 the charm that implements the `loki_push_api` interface, the library will inject a
 Pebble layer that runs Promtail in the workload container to send logs.
 
-The default behaivour is that Promtail binary that is injected into the workload container
-is downloaded from internet, but in some scenarios workload containers cannot reach internet.
-To enable people operating in these situations, the following section should be added to the
-`resources` section of your charm's `metadata.yaml`, which will allow operators to attach a binary
-at runtime should they need, rather than rely on fetching from the internet.
+By default, the promtail binary injected into the container will be downloaded from the internet.
+If for any reason, the container has limited network access, you may allow charm
+administrators to provide their own promtail binary at runtime by adding the following snippet to
+your charm metadata:
 
 ```yaml
 resources:

--- a/lib/charms/loki_k8s/v0/log_proxy.py
+++ b/lib/charms/loki_k8s/v0/log_proxy.py
@@ -81,6 +81,20 @@ Once the library is implemented in a charmed operator and a relation is establis
 the charm that implements the `loki_push_api` interface, the library will inject a
 Pebble layer that runs Promtail in the workload container to send logs.
 
+The defaul behaivour is that Promtail binary that is injected into the workload container
+is downloaded from internet, but in some scenarios workload containers cannot reach internet.
+In this situation Promtail binary must be uploaded to charmhub (Follow the instructions: https://juju.is/docs/sdk/publishing-resources)
+and the following section added to `resources` section in metadata.yaml
+
+```yaml
+resources:
+  promtail-bin:
+      type: file
+      description: Promtail binary for logging
+      filename: promtail-linux-amd64
+```
+
+
 The object can raise a `PromtailDigestError` when:
 
 - Promtail binary cannot be downloaded.

--- a/lib/charms/loki_k8s/v0/log_proxy.py
+++ b/lib/charms/loki_k8s/v0/log_proxy.py
@@ -83,7 +83,9 @@ Pebble layer that runs Promtail in the workload container to send logs.
 
 The default behaivour is that Promtail binary that is injected into the workload container
 is downloaded from internet, but in some scenarios workload containers cannot reach internet.
-In this situation the following section should be added to `resources` section in metadata.yaml
+To enable people operating in these situations, the following section should be added to the 
+`resources` section of your charm's `metadata.yaml`, which will allow operators to attach a binary
+at runtime should they need, rather than rely on fetching from the internet.
 
 ```yaml
 resources:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -51,5 +51,5 @@ requires:
 resources:
   loki-image:
     type: oci-image
-    description: OCI image
+    description: Loki OCI image "grafana/loki:2.4.1"
     upstream-source: grafana/loki:2.4.1

--- a/tests/unit/test_log_proxy_consumer.py
+++ b/tests/unit/test_log_proxy_consumer.py
@@ -211,7 +211,7 @@ class TestLogProxyConsumer(unittest.TestCase):
                 self.assertEqual(
                     sorted(logger.output),
                     [
-                        "DEBUG:charms.loki_k8s.v0.log_proxy:Promtail binary file has been obtained from an attached resource."
+                        "INFO:charms.loki_k8s.v0.log_proxy:Promtail binary file has been obtained from an attached resource."
                     ],
                 )
 

--- a/tests/unit/test_log_proxy_consumer.py
+++ b/tests/unit/test_log_proxy_consumer.py
@@ -230,12 +230,6 @@ class TestLogProxyConsumer(unittest.TestCase):
         self.assertTrue(self.harness.charm._log_proxy._promtail_must_be_downloaded())
 
     def test__promtail_must_be_downloaded_in_workload_sha256_match(self):
-        self.harness.charm._log_proxy._is_promtail_binary_in_workload = MagicMock(
-            return_value=True
-        )
-        self.harness.charm._log_proxy._get_promtail_bin_from_workload = MagicMock(
-            return_value=True
-        )
         self.harness.charm._log_proxy._sha256sums_matches = MagicMock(return_value=True)
 
         with self.assertLogs(level="DEBUG") as logger:

--- a/tests/unit/test_log_proxy_consumer.py
+++ b/tests/unit/test_log_proxy_consumer.py
@@ -230,6 +230,7 @@ class TestLogProxyConsumer(unittest.TestCase):
         self.assertTrue(self.harness.charm._log_proxy._promtail_must_be_downloaded())
 
     def test__promtail_must_be_downloaded_in_workload_sha256_match(self):
+        self.harness.charm._log_proxy._is_promtail_binary_in_charm = MagicMock(return_value=True)
         self.harness.charm._log_proxy._sha256sums_matches = MagicMock(return_value=True)
 
         with self.assertLogs(level="DEBUG") as logger:


### PR DESCRIPTION
When a relation is established between the consumer and the provider side, the library checks whether Promtail binary is attached as a resource in the consumer side or not.
If it's attached uses that binary, if not checks if it's already downloaded and use that downloaded binary. If it's not downloaded, downloads it.
