### PR TITLE
Emit custom event if there is an error with alert rules.

### DIFF
--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -941,6 +941,16 @@ class LokiPushApiConsumer(RelationManagerBase):
             RelationRoleMismatchError: If the relation with the same name as provided
                 via `relation_name` argument does not have the `RelationRole.provides`
                 role.
+
+        Emits:
+            loki_push_api_endpoint_joined: This event is emitted when the relation between the
+                charmed operator that implements `LokiPushApiProvider` (Loki charm for instance) and
+                the charmed operator that implements `LokiPushApiConsumer` is established.
+            loki_push_api_endpoint_departed: This event is emitted when the relation between the
+                charmed operator that implements `LokiPushApiProvider` (Loki charm for instance) and
+                the charmed operator that implements `LokiPushApiConsumer` is removed.
+             loki_push_api_alert_rules_error: This event is emitted whether alert rules files does
+                not contain the keys `alert` or `expr` or there is no alert rules file in `alert_rules_path`.
         """
         _validate_relation_by_interface_and_direction(
             charm, relation_name, RELATION_INTERFACE_NAME, RelationRole.requires

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -942,9 +942,8 @@ class LokiPushApiConsumer(RelationManagerBase):
             loki_push_api_endpoint_departed: This event is emitted when the relation between the
                 charmed operator that implements `LokiPushApiProvider` (Loki charm for instance)
                 and the charmed operator that implements `LokiPushApiConsumer` is removed.
-            loki_push_api_alert_rules_error: This event is emitted whether alert rules files does
-                not contain the keys `alert` or `expr` or there is no alert rules file in
-                `alert_rules_path`.
+            loki_push_api_alert_rules_error: This event is emitted when an invalid alert rules
+                file is encountered or if `alert_rules_path` is empty.
         """
         _validate_relation_by_interface_and_direction(
             charm, relation_name, RELATION_INTERFACE_NAME, RelationRole.requires

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -944,13 +944,14 @@ class LokiPushApiConsumer(RelationManagerBase):
 
         Emits:
             loki_push_api_endpoint_joined: This event is emitted when the relation between the
-                charmed operator that implements `LokiPushApiProvider` (Loki charm for instance) and
-                the charmed operator that implements `LokiPushApiConsumer` is established.
+                charmed operator that implements `LokiPushApiProvider` (Loki charm for instance)
+                and the charmed operator that implements `LokiPushApiConsumer` is established.
             loki_push_api_endpoint_departed: This event is emitted when the relation between the
-                charmed operator that implements `LokiPushApiProvider` (Loki charm for instance) and
-                the charmed operator that implements `LokiPushApiConsumer` is removed.
+                charmed operator that implements `LokiPushApiProvider` (Loki charm for instance)
+                and the charmed operator that implements `LokiPushApiConsumer` is removed.
              loki_push_api_alert_rules_error: This event is emitted whether alert rules files does
-                not contain the keys `alert` or `expr` or there is no alert rules file in `alert_rules_path`.
+                not contain the keys `alert` or `expr` or there is no alert rules file in
+                `alert_rules_path`.
         """
         _validate_relation_by_interface_and_direction(
             charm, relation_name, RELATION_INTERFACE_NAME, RelationRole.requires

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -949,7 +949,7 @@ class LokiPushApiConsumer(RelationManagerBase):
             loki_push_api_endpoint_departed: This event is emitted when the relation between the
                 charmed operator that implements `LokiPushApiProvider` (Loki charm for instance)
                 and the charmed operator that implements `LokiPushApiConsumer` is removed.
-             loki_push_api_alert_rules_error: This event is emitted whether alert rules files does
+            loki_push_api_alert_rules_error: This event is emitted whether alert rules files does
                 not contain the keys `alert` or `expr` or there is no alert rules file in
                 `alert_rules_path`.
         """

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -309,13 +309,6 @@ DEFAULT_RELATION_NAME = "logging"
 DEFAULT_ALERT_RULES_RELATIVE_PATH = "./src/loki_alert_rules"
 
 
-class AlertRulesError(Exception):
-    """Raised if there is an error with alert rules."""
-
-    def __init__(self, message: str):
-        super().__init__(message)
-
-
 class RelationNotFoundError(ValueError):
     """Raised if there is no relation with the given name."""
 

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -937,8 +937,8 @@ class LokiPushApiConsumer(RelationManagerBase):
 
         Emits:
             loki_push_api_endpoint_joined: This event is emitted when the relation between the
-                charmed operator that implements `LokiPushApiProvider` (Loki charm for instance)
-                and the charmed operator that implements `LokiPushApiConsumer` is established.
+                charmed operator that instantiates `LokiPushApiProvider` (Loki charm for instance)
+                and the charmed operator that instantiates `LokiPushApiConsumer` is established.
             loki_push_api_endpoint_departed: This event is emitted when the relation between the
                 charmed operator that implements `LokiPushApiProvider` (Loki charm for instance)
                 and the charmed operator that implements `LokiPushApiConsumer` is removed.

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -974,9 +974,8 @@ class LokiPushApiConsumer(RelationManagerBase):
 
         Emits:
             loki_push_api_endpoint_joined: Once the relation is established, this event is emitted.
-            loki_push_api_alert_rules_error: This event is emitted whether alert rules files does
-                not contain the keys `alert` or `expr` or there is no alert rules file in
-                `alert_rules_path`.
+            loki_push_api_alert_rules_error: This event is emitted when an invalid alert rules
+                file is encountered or if `alert_rules_path` is empty.
         """
         if not self._charm.unit.is_leader():
             return

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -98,11 +98,11 @@ class TestLokiPushApiConsumer(unittest.TestCase):
         )
 
     @patch(
-        "charms.loki_k8s.v0.loki_push_api.LokiPushApiConsumer._labeled_alert_groups",
+        "charms.loki_k8s.v0.loki_push_api.load_alert_rules_from_dir",
         new_callable=PropertyMock,
     )
     def test__on_logging_relation_changed(self, mock_alert_rules):
-        mock_alert_rules.return_value = LABELED_ALERT_RULES
+        mock_alert_rules.return_value = (LABELED_ALERT_RULES, [])
         loki_push_api = "http://10.1.2.3:3100/loki/api/v1/push"
         self.harness.set_leader(True)
         rel_id = self.harness.add_relation("logging", "promtail")


### PR DESCRIPTION
Before this PR we were setting (in the library) `BlockedStatus` in the unit if there was an error with alert rules.

Now whether alert rules files does not contain the keys `alert` or `expr` or
there is no alert rules file in `alert_rules_path` a `loki_push_api_alert_rules_error` event
is emitted.

For this, in this PR we:
- created a custom event: `LokiPushApiAlertRulesError`
- refactor some methods