### PR TITLE
Add support for loki 3

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -133,7 +133,7 @@ resources:
   loki-image:
     type: oci-image
     description: Loki OCI image
-    upstream-source: docker.io/ubuntu/loki:2-22.04
+    upstream-source: docker.io/ubuntu/loki:3-24.04
   node-exporter-image:
     type: oci-image
     description: Node-exporter OCI image

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -180,12 +180,10 @@ class ConfigBuilder:
         return {
             "boltdb_shipper": {
                 "active_index_directory": BOLTDB_DIR,
-                "shared_store": "filesystem",
                 "cache_location": BOLTDB_CACHE_DIR,
             },
             "tsdb_shipper": {
                 "active_index_directory": TSDB_DIR,
-                "shared_store": "filesystem",
                 "cache_location": TSDB_CACHE_DIR,
             },
             "filesystem": {"directory": CHUNKS_DIR},
@@ -263,7 +261,6 @@ class ConfigBuilder:
             # Activate custom retention. Default is False.
             "retention_enabled": retention_enabled,
             "working_directory": COMPACTOR_DIR,
-            "shared_store": "filesystem",
         }
 
     @property

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -51,7 +51,6 @@ auth_enabled: false
 chunk_store_config:
   max_look_back_period: 0s
 compactor:
-  shared_store: filesystem
   working_directory: /loki/boltdb-shipper-compactor
 ingester:
   chunk_idle_period: 1h
@@ -96,7 +95,6 @@ storage_config:
     active_index_directory: /loki/boltdb-shipper-active
     cache_location: /loki/boltdb-shipper-cache
     cache_ttl: 24h
-    shared_store: filesystem
   filesystem:
     directory: /loki/chunks
 table_manager:


### PR DESCRIPTION
The loki image was changed to 3-24.04 and the configuration file updated to remove the deprecated shared_store parameter [[1]](https://grafana.com/docs/loki/latest/setup/upgrade/#removed-shared_store-and-shared_store_key_prefix-from-shipper-configuration) [[2]](https://grafana.com/docs/loki/latest/setup/upgrade/#removed-shared_store-and-shared_store_key_prefix-from-compactor-configuration)

