### PR TITLE
fix: deduplicate endpoints when Loki is scaled

### DIFF
--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -1621,6 +1621,10 @@ class ConsumerBase(Object):
                 deserialized_endpoint = json.loads(endpoint)
                 url = deserialized_endpoint.get("url")
 
+                # It's necessary to deduplicte the endpoints because if we don't do this, in the event that Loki coordinator is related to Flog and is scaled,
+                # in the /etc/promtail/promtail_config.yaml of Flog, there will duplicate entries for each unit of the Loki coordinator, which will cause Flog to go into error due to the duplication.
+                # The deduplication applied here
+
                 if not url or url in seen_urls:
                     continue
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Currently, the way the `loki_push_api` lib is written, when something like Flog is related to Loki HA (which doesn't do ingress per unit), then, in Flog's `promtail_config`, the URL for `promtail` clients is duplicated, which causes Flog to go into error state. For example, if you scale Loki coordinator up to 3, then, the clients in `promtail_config` will look like something like:
```
clients:
- tls_config:
    insecure_skip_verify: true
  url: http://10.181.160.194/test-my-loki/loki/api/v1/push
- tls_config:
    insecure_skip_verify: true
  url: http://10.181.160.194/test-my-loki/loki/api/v1/push
- tls_config:
    insecure_skip_verify: true
  url: http://10.181.160.194/test-my-loki/loki/api/v1/push
```
The URL duplication will result in an error in Flog: `hook failed: log-proxy-relation changed`
## Solution
<!-- A summary of the solution addressing the above issue -->
We need to deduplicate the endpoints list so we don't end up with duplicated URLs. After these changes, the config will be:
```
- tls_config:
    insecure_skip_verify: true
  url: http://10.181.160.194/test-my-loki/loki/api/v1/push
```


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
This change is necessary to resolve Flog in [this integration test](https://github.com/canonical/loki-coordinator-k8s-operator/blob/main/tests/integration/test_charm_ha_scaled.py) for Loki Coordinator. After this PR is merged, we need to update the library in Flog and push to stable for this `iTest` to pass. The updated config above is when the changes are locally applied to Flog's `loki_push_api`.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
