### PR TITLE
fix: honor self.address

### DIFF
--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -1305,7 +1305,7 @@ class LokiPushApiProvider(Object):
 
         # If the self.address is set, try use that or fallback.
         url = self._build_url_from_address()
-        
+
         if url:
             self.update_endpoint(url=url, relation=relation)
         else:


### PR DESCRIPTION
## Issue
Fixes #554 - The problem with address being ignored.


## Solution
This fix looks for a set self.address, validates it and uses it on the relation or falls back to the default behaviour (passing the hostname).