### PR TITLE
feat: Store updated PushAPI endpoint

### DIFF
--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -545,7 +545,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 22
+LIBPATCH = 23
 
 PYDEPS = ["cosl"]
 
@@ -1200,6 +1200,7 @@ class LokiPushApiProvider(Object):
         self.port = int(port)
         self.scheme = scheme
         self.path = path
+        self.custom_url = None
 
         events = self._charm.on[relation_name]
         self.framework.observe(self._charm.on.upgrade_charm, self._on_lifecycle_event)
@@ -1350,7 +1351,10 @@ class LokiPushApiProvider(Object):
         else:
             relations_list = [relation]
 
-        endpoint = self._endpoint(url or self._url)
+        if url:
+            self.custom_url = url
+
+        endpoint = self._endpoint(self.custom_url or self._url)
 
         for relation in relations_list:
             relation.data[self._charm.unit].update({"endpoint": json.dumps(endpoint)})

--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -1200,7 +1200,7 @@ class LokiPushApiProvider(Object):
         self.port = int(port)
         self.scheme = scheme
         self.path = path
-        self.custom_url = None
+        self._custom_url = None
 
         events = self._charm.on[relation_name]
         self.framework.observe(self._charm.on.upgrade_charm, self._on_lifecycle_event)
@@ -1352,9 +1352,9 @@ class LokiPushApiProvider(Object):
             relations_list = [relation]
 
         if url:
-            self.custom_url = url
+            self._custom_url = url
 
-        endpoint = self._endpoint(self.custom_url or self._url)
+        endpoint = self._endpoint(self._custom_url or self._url)
 
         for relation in relations_list:
             relation.data[self._charm.unit].update({"endpoint": json.dumps(endpoint)})

--- a/tests/unit/test_charm_logging.py
+++ b/tests/unit/test_charm_logging.py
@@ -1,9 +1,10 @@
+import json
 import logging
 from unittest.mock import patch
 
 import ops.pebble
 import pytest
-from ops.testing import Container, Exec, State
+from ops.testing import Container, Exec, Relation, State
 
 
 @pytest.fixture
@@ -86,3 +87,23 @@ def test_endpoints_on_loki_ready_tls(_, context, loki_emitter):
         if record.filename == __name__ + ".py":  # log emitted by this module
             assert record.msg == "bar"
             assert record.name == "foo"
+
+
+def test_update_endpoints(context, loki_container):
+    # GIVEN a logging relation
+    logging = Relation("logging")
+    state = State(containers=[loki_container], relations=[logging])
+
+    with context(context.on.relation_changed(logging), state) as mgr:
+        charm = mgr.charm
+        state_out = mgr.run()
+        unit_data = state_out.get_relations(logging.endpoint)[0].local_unit_data
+        assert json.loads(unit_data["endpoint"])["url"] == "http://fqdn:3100/loki/api/v1/push"
+        # WHEN the endpoint is updated
+        charm.loki_provider.update_endpoint("http://foo")
+        # THEN the endpoint is updated
+        assert json.loads(unit_data["endpoint"])["url"] == "http://foo/loki/api/v1/push"
+        # WHEN the endpoint is updated to an False-like value
+        charm.loki_provider.update_endpoint("")
+        # THEN the endpoint is not updated
+        assert json.loads(unit_data["endpoint"])["url"] == "http://foo/loki/api/v1/push"


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
This PR in otelcol:
- https://github.com/canonical/opentelemetry-collector-k8s-operator/pull/173

Requires updating the `endpoint` field in the LokiPushApiProvider databag. This worked fine previously for non-reconciler charms, but now we need support for our common reconciler-pattern charms.

## Solution
<!-- A summary of the solution addressing the above issue -->
Add a new attribute named `_custom_url` which is set when the public `update_endpoint` method is called. This defaults to `None` and the `endpoint` field will always revert to `self._url` if `self._custom_url` is not set.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
