### PR TITLE
chore: Revert lib-patch so we can release the lib

### DIFF
--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -545,7 +545,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 23
+LIBPATCH = 22
 
 PYDEPS = ["cosl"]
 
@@ -1337,6 +1337,11 @@ class LokiPushApiProvider(Object):
         the `logging` relation lifecycle, e.g., in case of a
         host address change because the charmed operator becomes connected to an
         Ingress after the `logging` relation is established.
+
+        To make this library reconciler-friendly, the endpoint URL was made sticky i.e., once the
+        endpoint is updated with a custom URL, using the public method, it cannot be unset. Users
+        of this method should set the "url" arg to an internal URL if the charms ingress is no
+        longer available.
 
         Args:
             url: An optional url value to update relation data.


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
[This release fails](https://github.com/canonical/loki-k8s-operator/actions/runs/21211012515/job/61025437211#step:3:32) because we didn't monitor the previous release action until success.

## Solution
<!-- A summary of the solution addressing the above issue -->


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
