### PR TITLE
fix: prevent v13 schema date drift on pod churn and upgrades

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -319,12 +319,11 @@ class LokiOperatorCharm(CharmBase):
         self._configure()
 
     def _on_upgrade_charm(self, _):
-        # Note: If the pod is rescheduled during startup (e.g., by manual kubectl delete
-        # or resource limit patch), the `upgrade-charm` event might trigger prematurely,
-        # This could incorrectly set the TSDB date to the upgrade day, instead of the following day,
-        # potentially corrupting logs received on that day. Subsequent logs should be healthy.
-        # Documenting for troubleshooting; automatic handling may not be necessary due to the complexity
-        # of guarding against this rare edge case.
+        # Mark as upgrade so that the initial v13 schema date (if not yet persisted in the
+        # backup config) is set to tomorrow rather than today, preserving today's logs that
+        # were written under the previous v11/v12 schema.
+        # The backup config on persistent storage is the primary safeguard against date drift;
+        # this flag only matters on the very first config generation after an upgrade.
         self._stored.fresh_install = False
         self._configure()
 
@@ -898,41 +897,40 @@ class LokiOperatorCharm(CharmBase):
 
     @property
     def _tsdb_versions_migration_dates(self) -> List[Dict[str, str]]:
-        # If v13_migration_date isn't set (due to missing or failed retrieval),
-        # we determine the migration date for v13 schema. This occurs once
-        # during initial setup, as subsequent hooks will get the value from the persisted backup config.
-
-        # If it's a fresh Loki installation, it's safe to set the v13 schema date to today.
-        # This ensures that logs are correctly managed in v13 from the beginning of Loki's operation.
-        # If it's an upgrade scenario, we set the date to tomorrow to accommodate today's logs
-        # that might have been written in the previous v11/v12 schema formats.
-
-        # By default, we assume it's a fresh installation unless state explicitly set to False
-        # by the upgrade hook, indicating an upgrade
+        # Always read migration dates from the persisted backup config first.
+        # The backup (on persistent storage) is the source of truth — this ensures
+        # idempotency across pod churns, upgrades, and any event that triggers _configure().
+        #
+        # The v13 date is computed only once (when no backup exists yet):
+        # - Fresh install: today (no pre-existing logs)
+        # - Upgrade from older charm (v11/v12 only): tomorrow (preserves today's logs
+        #   written under the previous schema)
 
         date_format = "%Y-%m-%d"
         today = datetime.datetime.now(datetime.timezone.utc)
 
-        if self._stored.fresh_install:
-            return [{"version": "v13", "date": today.strftime(date_format)}]
-
         ret = []
 
-        if v12_migration_date := self._get_schema_config_version_migration_date_from_backup("v12"):
+        v12_migration_date = self._get_schema_config_version_migration_date_from_backup("v12")
+        if v12_migration_date:
             ret.append({"version": "v12", "date": v12_migration_date})
 
-        if v13_migration_date := self._get_schema_config_version_migration_date_from_backup("v13"):
+        v13_migration_date = self._get_schema_config_version_migration_date_from_backup("v13")
+        if v13_migration_date:
             ret.append({"version": "v13", "date": v13_migration_date})
             return ret
 
-        tomorrow = today + datetime.timedelta(days=1)
+        # No v13 in backup — first time determining the date.
+        if self._stored.fresh_install:
+            ret.append({"version": "v13", "date": today.strftime(date_format)})
+        else:
+            tomorrow = today + datetime.timedelta(days=1)
+            if v12_migration_date and tomorrow.strftime(date_format) == v12_migration_date:
+                after_tomorrow = tomorrow + datetime.timedelta(days=1)
+                ret.append({"version": "v13", "date": after_tomorrow.strftime(date_format)})
+            else:
+                ret.append({"version": "v13", "date": tomorrow.strftime(date_format)})
 
-        if tomorrow.strftime(date_format) == v12_migration_date:
-            after_tomorrow = tomorrow + datetime.timedelta(days=1)
-            ret.append({"version": "v13", "date": after_tomorrow.strftime(date_format)})
-            return ret
-
-        ret.append({"version": "v13", "date": tomorrow.strftime(date_format)})
         return ret
 
     def _update_datasource_exchange(self) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -149,6 +149,7 @@ class LokiOperatorCharm(CharmBase):
                 retention=to_tuple(ActiveStatus()),
             ),
             fresh_install=True,
+            v13_migration_date="",
         )
 
         self._loki_container = self.unit.get_container(self._name)
@@ -901,7 +902,11 @@ class LokiOperatorCharm(CharmBase):
         # The backup (on persistent storage) is the source of truth — this ensures
         # idempotency across pod churns, upgrades, and any event that triggers _configure().
         #
-        # The v13 date is computed only once (when no backup exists yet):
+        # Stored state (Juju controller DB) is used as a secondary fallback, because
+        # the backup file may be temporarily unavailable during pod recreation (e.g. PVC
+        # not yet remounted when pebble is already connectable).
+        #
+        # The v13 date is computed only once (when neither backup nor stored state has it):
         # - Fresh install: today (no pre-existing logs)
         # - Upgrade from older charm (v11/v12 only): tomorrow (preserves today's logs
         #   written under the previous schema)
@@ -917,20 +922,28 @@ class LokiOperatorCharm(CharmBase):
 
         v13_migration_date = self._get_schema_config_version_migration_date_from_backup("v13")
         if v13_migration_date:
+            self._stored.v13_migration_date = v13_migration_date
             ret.append({"version": "v13", "date": v13_migration_date})
             return ret
 
-        # No v13 in backup — first time determining the date.
+        # Backup unavailable or has no v13 — fall back to stored state.
+        if self._stored.v13_migration_date:
+            ret.append({"version": "v13", "date": self._stored.v13_migration_date})
+            return ret
+
+        # No v13 anywhere — first time determining the date.
         if self._stored.fresh_install:
-            ret.append({"version": "v13", "date": today.strftime(date_format)})
+            v13_date = today.strftime(date_format)
         else:
             tomorrow = today + datetime.timedelta(days=1)
             if v12_migration_date and tomorrow.strftime(date_format) == v12_migration_date:
                 after_tomorrow = tomorrow + datetime.timedelta(days=1)
-                ret.append({"version": "v13", "date": after_tomorrow.strftime(date_format)})
+                v13_date = after_tomorrow.strftime(date_format)
             else:
-                ret.append({"version": "v13", "date": tomorrow.strftime(date_format)})
+                v13_date = tomorrow.strftime(date_format)
 
+        self._stored.v13_migration_date = v13_date
+        ret.append({"version": "v13", "date": v13_date})
         return ret
 
     def _update_datasource_exchange(self) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -61,6 +61,7 @@ from ops.model import (
     BlockedStatus,
     MaintenanceStatus,
     Port,
+    Relation,
     StatusBase,
     WaitingStatus,
 )
@@ -68,6 +69,7 @@ from ops.pebble import Error, Layer, PathError, ProtocolError
 
 from config_builder import (
     CERT_FILE,
+    CHUNKS_DIR,
     HTTP_LISTEN_PORT,
     KEY_FILE,
     LOKI_CONFIG,
@@ -148,8 +150,6 @@ class LokiOperatorCharm(CharmBase):
                 rules=to_tuple(ActiveStatus()),
                 retention=to_tuple(ActiveStatus()),
             ),
-            fresh_install=True,
-            v13_migration_date="",
         )
 
         self._loki_container = self.unit.get_container(self._name)
@@ -326,10 +326,11 @@ class LokiOperatorCharm(CharmBase):
         config) is set to tomorrow rather than today, preserving today's logs that were
         written under the previous v11/v12 schema.
 
+        The flag is stored in the peer relation app databag so it survives pod churns.
         The backup config on persistent storage is the primary safeguard against date drift;
         this flag only matters on the very first config generation after an upgrade.
         """
-        self._stored.fresh_install = False
+        self._peer_data_set("fresh_install", "false")
         self._configure()
 
     def _on_certificate_available(self, _):
@@ -375,6 +376,32 @@ class LokiOperatorCharm(CharmBase):
     ##############################################
     #                 PROPERTIES                 #
     ##############################################
+
+    @property
+    def _peers(self) -> Optional[Relation]:
+        """Return the peer relation, or None if not yet available."""
+        return self.model.get_relation("replicas")
+
+    def _peer_data_get(self, key: str) -> str:
+        """Read a value from the peer relation app databag.
+
+        Returns empty string if the peer relation is unavailable or the key is absent.
+        """
+        if (peers := self._peers) is None:
+            return ""
+        return peers.data[self.app].get(key, "")
+
+    def _peer_data_set(self, key: str, value: str) -> None:
+        """Write a value to the peer relation app databag.
+
+        No-op if the peer relation is not yet available or this unit is not the leader
+        (only the leader can write to the app databag).
+        """
+        if (peers := self._peers) is None:
+            return
+        if not self.unit.is_leader():
+            return
+        peers.data[self.app][key] = value
 
     @property
     def _catalogue_item(self) -> CatalogueItem:
@@ -731,6 +758,15 @@ class LokiOperatorCharm(CharmBase):
                 self._loki_container.pull(LOKI_CONFIG_BACKUP, encoding="utf-8").read()
             )
         except PathError:
+            try:
+                entries = self._loki_container.list_files(CHUNKS_DIR)
+                if any(e.name != "loki-local-config.yaml.bak" for e in entries):
+                    logger.warning(
+                        "Backup config missing but chunks directory has data. "
+                        "Schema dates may be inaccurate if the backup was deleted manually."
+                    )
+            except Error:
+                pass
             return ""
         except yaml.YAMLError as e:
             raise ValueError("Error parsing Loki backup config.") from e
@@ -908,14 +944,19 @@ class LokiOperatorCharm(CharmBase):
         The backup (on persistent storage) is the source of truth — this ensures
         idempotency across pod churns, upgrades, and any event that triggers _configure().
 
-        Stored state (Juju controller DB) is used as a secondary fallback, because
-        the backup file may be temporarily unavailable during pod recreation (e.g. PVC
-        not yet remounted when pebble is already connectable).
+        The peer relation app databag is used as a secondary fallback, because
+        the backup file may be temporarily unavailable (e.g. PathError during pod
+        recreation). Unlike StoredState, the peer databag persists for the lifetime
+        of the application and survives pod churns.
 
-        The v13 date is computed only once (when neither backup nor stored state has it):
+        The v13 date is computed only once (when neither backup nor peer data has it):
         - Fresh install: today (no pre-existing logs)
         - Upgrade from older charm (v11/v12 only): tomorrow (preserves today's logs
           written under the previous schema)
+
+        Fresh-vs-upgrade is determined by the peer databag 'fresh_install' key (set to
+        'false' by _on_upgrade_charm), with v12 presence in the backup as a secondary
+        signal (if v12 exists in backup, it's definitely not a fresh install).
         """
         date_format = "%Y-%m-%d"
         today = datetime.datetime.now(datetime.timezone.utc)
@@ -928,17 +969,26 @@ class LokiOperatorCharm(CharmBase):
 
         v13_migration_date = self._get_schema_config_version_migration_date_from_backup("v13")
         if v13_migration_date:
-            self._stored.v13_migration_date = v13_migration_date
+            self._peer_data_set("v13_migration_date", v13_migration_date)
             ret.append({"version": "v13", "date": v13_migration_date})
+            logger.info("Schema migration dates (from backup): %s", ret)
             return ret
 
-        # Backup unavailable or has no v13 — fall back to stored state.
-        if self._stored.v13_migration_date:
-            ret.append({"version": "v13", "date": self._stored.v13_migration_date})
+        # Backup unavailable or has no v13 — fall back to peer relation databag.
+        peer_v13 = self._peer_data_get("v13_migration_date")
+        if peer_v13:
+            ret.append({"version": "v13", "date": peer_v13})
+            logger.info("Schema migration dates (from peer data): %s", ret)
             return ret
 
         # No v13 anywhere — first time determining the date.
-        if self._stored.fresh_install:
+        # Determine fresh install vs upgrade:
+        #   - peer databag: absent key or "true" means fresh (default)
+        #   - v12 in backup: if present, it's definitely not fresh
+        peer_fresh = self._peer_data_get("fresh_install")
+        is_fresh = peer_fresh != "false" and not v12_migration_date
+
+        if is_fresh:
             v13_date = today.strftime(date_format)
         else:
             tomorrow = today + datetime.timedelta(days=1)
@@ -948,8 +998,9 @@ class LokiOperatorCharm(CharmBase):
             else:
                 v13_date = tomorrow.strftime(date_format)
 
-        self._stored.v13_migration_date = v13_date
+        self._peer_data_set("v13_migration_date", v13_date)
         ret.append({"version": "v13", "date": v13_date})
+        logger.info("Schema migration dates (computed): %s", ret)
         return ret
 
     def _update_datasource_exchange(self) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -320,11 +320,15 @@ class LokiOperatorCharm(CharmBase):
         self._configure()
 
     def _on_upgrade_charm(self, _):
-        # Mark as upgrade so that the initial v13 schema date (if not yet persisted in the
-        # backup config) is set to tomorrow rather than today, preserving today's logs that
-        # were written under the previous v11/v12 schema.
-        # The backup config on persistent storage is the primary safeguard against date drift;
-        # this flag only matters on the very first config generation after an upgrade.
+        """Handle upgrade-charm by marking this unit as an upgrade (not fresh install).
+
+        This ensures that the initial v13 schema date (if not yet persisted in the backup
+        config) is set to tomorrow rather than today, preserving today's logs that were
+        written under the previous v11/v12 schema.
+
+        The backup config on persistent storage is the primary safeguard against date drift;
+        this flag only matters on the very first config generation after an upgrade.
+        """
         self._stored.fresh_install = False
         self._configure()
 
@@ -898,19 +902,21 @@ class LokiOperatorCharm(CharmBase):
 
     @property
     def _tsdb_versions_migration_dates(self) -> List[Dict[str, str]]:
-        # Always read migration dates from the persisted backup config first.
-        # The backup (on persistent storage) is the source of truth — this ensures
-        # idempotency across pod churns, upgrades, and any event that triggers _configure().
-        #
-        # Stored state (Juju controller DB) is used as a secondary fallback, because
-        # the backup file may be temporarily unavailable during pod recreation (e.g. PVC
-        # not yet remounted when pebble is already connectable).
-        #
-        # The v13 date is computed only once (when neither backup nor stored state has it):
-        # - Fresh install: today (no pre-existing logs)
-        # - Upgrade from older charm (v11/v12 only): tomorrow (preserves today's logs
-        #   written under the previous schema)
+        """Return the schema version migration dates for the Loki TSDB config.
 
+        Always reads migration dates from the persisted backup config first.
+        The backup (on persistent storage) is the source of truth — this ensures
+        idempotency across pod churns, upgrades, and any event that triggers _configure().
+
+        Stored state (Juju controller DB) is used as a secondary fallback, because
+        the backup file may be temporarily unavailable during pod recreation (e.g. PVC
+        not yet remounted when pebble is already connectable).
+
+        The v13 date is computed only once (when neither backup nor stored state has it):
+        - Fresh install: today (no pre-existing logs)
+        - Upgrade from older charm (v11/v12 only): tomorrow (preserves today's logs
+          written under the previous schema)
+        """
         date_format = "%Y-%m-%d"
         today = datetime.datetime.now(datetime.timezone.utc)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -383,10 +383,7 @@ class LokiOperatorCharm(CharmBase):
         return self.model.get_relation("replicas")
 
     def _peer_data_get(self, key: str) -> str:
-        """Read a value from the peer relation app databag.
-
-        Returns empty string if the peer relation is unavailable or the key is absent.
-        """
+        """Returns the value of a given key from the peer data or empty string if the peer relation is unavailable or the key is absent."""
         if (peers := self._peers) is None:
             return ""
         return peers.data[self.app].get(key, "")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -551,7 +551,11 @@ class TestTsdbVersionsMigrationDates(unittest.TestCase):
         self.check_alert_rules_patcher.stop()
 
     def test_fresh_install_no_backup_uses_today(self):
-        """On a truly fresh install (no backup), v13 date should be today."""
+        """GIVEN a fresh install with no backup config and no stored v13 date.
+
+        WHEN _tsdb_versions_migration_dates is accessed
+        THEN the v13 date should be today.
+        """
         charm = self.harness.charm
         charm._stored.fresh_install = True  # type: ignore
         charm._stored.v13_migration_date = ""  # type: ignore
@@ -570,7 +574,11 @@ class TestTsdbVersionsMigrationDates(unittest.TestCase):
             self.assertEqual(v13_entries[0]["date"], expected)
 
     def test_fresh_install_with_backup_preserves_date(self):
-        """On a fresh install pod churn, backup date must take precedence over today."""
+        """GIVEN a fresh install where the backup config already has a v13 date.
+
+        WHEN _tsdb_versions_migration_dates is accessed after a pod churn
+        THEN the backup date takes precedence over today.
+        """
         charm = self.harness.charm
         charm._stored.fresh_install = True  # type: ignore
         original_date = "2026-01-15"
@@ -589,7 +597,11 @@ class TestTsdbVersionsMigrationDates(unittest.TestCase):
             self.assertEqual(v13_entries[0]["date"], original_date)
 
     def test_upgrade_with_backup_preserves_date(self):
-        """On upgrade, if backup has v13, the persisted date must be used."""
+        """GIVEN an upgrade where the backup config already has a v13 date.
+
+        WHEN _tsdb_versions_migration_dates is accessed
+        THEN the persisted backup date must be used.
+        """
         charm = self.harness.charm
         charm._stored.fresh_install = False  # type: ignore
         original_date = "2026-01-15"
@@ -608,7 +620,11 @@ class TestTsdbVersionsMigrationDates(unittest.TestCase):
             self.assertEqual(v13_entries[0]["date"], original_date)
 
     def test_upgrade_no_backup_uses_tomorrow(self):
-        """On upgrade from v11-only (no v13 in backup or stored state), v13 date should be tomorrow."""
+        """GIVEN an upgrade from v11-only with no v13 in backup or stored state.
+
+        WHEN _tsdb_versions_migration_dates is accessed
+        THEN the v13 date should be tomorrow to preserve today's v11/v12 logs.
+        """
         charm = self.harness.charm
         charm._stored.fresh_install = False  # type: ignore
         charm._stored.v13_migration_date = ""  # type: ignore
@@ -629,7 +645,11 @@ class TestTsdbVersionsMigrationDates(unittest.TestCase):
             self.assertEqual(v13_entries[0]["date"], expected)
 
     def test_stored_state_fallback_when_backup_unavailable(self):
-        """When the backup file is unavailable, stored state must prevent date drift."""
+        """GIVEN a v13 date persisted in stored state but the backup file is unavailable.
+
+        WHEN _tsdb_versions_migration_dates is accessed (e.g. PVC not yet remounted)
+        THEN the stored state date is returned, preventing date drift.
+        """
         charm = self.harness.charm
         charm._stored.fresh_install = False  # type: ignore
         original_date = "2026-01-15"
@@ -647,7 +667,11 @@ class TestTsdbVersionsMigrationDates(unittest.TestCase):
             self.assertEqual(v13_entries[0]["date"], original_date)
 
     def test_backup_syncs_to_stored_state(self):
-        """Reading v13 from backup must also persist the date in stored state."""
+        """GIVEN a v13 date in the backup config but not yet in stored state.
+
+        WHEN _tsdb_versions_migration_dates is accessed
+        THEN the backup date is also persisted into stored state for future fallback.
+        """
         charm = self.harness.charm
         charm._stored.v13_migration_date = ""  # type: ignore
         original_date = "2026-01-15"
@@ -664,7 +688,11 @@ class TestTsdbVersionsMigrationDates(unittest.TestCase):
             self.assertEqual(charm._stored.v13_migration_date, original_date)  # type: ignore
 
     def test_v13_date_stable_across_config_changed_events(self):
-        """The v13 date must not drift when config-changed fires on a later day."""
+        """GIVEN a fully configured Loki with a v13 date already pushed.
+
+        WHEN config-changed fires again (e.g. pod churn on a later day)
+        THEN the v13 date in the pushed config must remain unchanged.
+        """
         charm = self.harness.charm
         container = charm.unit.get_container("loki")
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -523,3 +523,133 @@ class TestAlertRuleBlockedStatus(unittest.TestCase):
         self.harness.charm.on.config_changed.emit()
         self.harness.evaluate_status()
         self.assertIsInstance(self.harness.charm.unit.status, ActiveStatus)
+
+
+class TestTsdbVersionsMigrationDates(unittest.TestCase):
+    """Feature: The v13 schema 'from' date must be computed once and then frozen in the backup."""
+
+    @patch("socket.getfqdn", new=lambda *args: "fqdn")
+    @k8s_resource_multipatch
+    @patch("lightkube.core.client.GenericSyncClient")
+    @patch.object(Container, "exec", new=FakeProcessVersionCheck)
+    def setUp(self, *_):
+        os.environ["JUJU_VERSION"] = "3.0.3"
+        self.check_alert_rules_patcher = patch(
+            "charm.LokiOperatorCharm._check_alert_rules",
+            new=lambda x: True,
+        )
+        self.check_alert_rules_patcher.start()
+
+        self.harness = Harness(LokiOperatorCharm)
+        self.addCleanup(self.harness.cleanup)
+        self.harness.set_leader(True)
+        self.harness.handle_exec("loki", ["update-ca-certificates"], result=0)
+        self.harness.begin_with_initial_hooks()
+        self.harness.container_pebble_ready("loki")
+
+    def tearDown(self):
+        self.check_alert_rules_patcher.stop()
+
+    def test_fresh_install_no_backup_uses_today(self):
+        """On a truly fresh install (no backup), v13 date should be today."""
+        charm = self.harness.charm
+        charm._stored.fresh_install = True  # type: ignore
+
+        with patch.object(
+            type(charm),
+            "_get_schema_config_version_migration_date_from_backup",
+            return_value="",
+        ):
+            dates = charm._tsdb_versions_migration_dates  # type: ignore
+            v13_entries = [d for d in dates if d["version"] == "v13"]
+            self.assertEqual(len(v13_entries), 1)
+            import datetime
+
+            expected = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")
+            self.assertEqual(v13_entries[0]["date"], expected)
+
+    def test_fresh_install_with_backup_preserves_date(self):
+        """On a fresh install pod churn, backup date must take precedence over today."""
+        charm = self.harness.charm
+        charm._stored.fresh_install = True  # type: ignore
+        original_date = "2026-01-15"
+
+        def mock_backup(self_inner, sc_version):
+            return {"v13": original_date, "v12": ""}.get(sc_version, "")
+
+        with patch.object(
+            type(charm),
+            "_get_schema_config_version_migration_date_from_backup",
+            mock_backup,
+        ):
+            dates = charm._tsdb_versions_migration_dates  # type: ignore
+            v13_entries = [d for d in dates if d["version"] == "v13"]
+            self.assertEqual(len(v13_entries), 1)
+            self.assertEqual(v13_entries[0]["date"], original_date)
+
+    def test_upgrade_with_backup_preserves_date(self):
+        """On upgrade, if backup has v13, the persisted date must be used."""
+        charm = self.harness.charm
+        charm._stored.fresh_install = False  # type: ignore
+        original_date = "2026-01-15"
+
+        def mock_backup(self_inner, sc_version):
+            return {"v13": original_date, "v12": ""}.get(sc_version, "")
+
+        with patch.object(
+            type(charm),
+            "_get_schema_config_version_migration_date_from_backup",
+            mock_backup,
+        ):
+            dates = charm._tsdb_versions_migration_dates  # type: ignore
+            v13_entries = [d for d in dates if d["version"] == "v13"]
+            self.assertEqual(len(v13_entries), 1)
+            self.assertEqual(v13_entries[0]["date"], original_date)
+
+    def test_upgrade_no_backup_uses_tomorrow(self):
+        """On upgrade from v11-only (no v13 in backup), v13 date should be tomorrow."""
+        charm = self.harness.charm
+        charm._stored.fresh_install = False  # type: ignore
+
+        with patch.object(
+            type(charm),
+            "_get_schema_config_version_migration_date_from_backup",
+            return_value="",
+        ):
+            dates = charm._tsdb_versions_migration_dates  # type: ignore
+            v13_entries = [d for d in dates if d["version"] == "v13"]
+            self.assertEqual(len(v13_entries), 1)
+            import datetime
+
+            expected = (
+                datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
+            ).strftime("%Y-%m-%d")
+            self.assertEqual(v13_entries[0]["date"], expected)
+
+    def test_v13_date_stable_across_config_changed_events(self):
+        """The v13 date must not drift when config-changed fires on a later day."""
+        charm = self.harness.charm
+        container = charm.unit.get_container("loki")
+
+        # After setUp, a config with v13 has already been pushed.
+        # Read the v13 date from the generated config.
+        config = yaml.safe_load(container.pull(LOKI_CONFIG_PATH))
+        original_v13_date = None
+        for sc in config["schema_config"]["configs"]:
+            if sc.get("schema") == "v13":
+                original_v13_date = sc["from"]
+                break
+        self.assertIsNotNone(original_v13_date, "v13 schema should be present after setUp")
+
+        # Simulate a config-changed event (e.g., pod churn on a later day).
+        # The backup file should ensure the date is preserved.
+        self.harness.charm.on.config_changed.emit()
+
+        config_after = yaml.safe_load(container.pull(LOKI_CONFIG_PATH))
+        v13_date_after = None
+        for sc in config_after["schema_config"]["configs"]:
+            if sc.get("schema") == "v13":
+                v13_date_after = sc["from"]
+                break
+        self.assertEqual(original_v13_date, v13_date_after)
+

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3,6 +3,7 @@
 #
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
+import datetime
 import json
 import os
 import unittest
@@ -564,6 +565,13 @@ class TestTsdbVersionsMigrationDates(unittest.TestCase):
         assert peer_rel is not None
         return peer_rel.data[charm.app].get(key, "")
 
+    @staticmethod
+    def _mock_backup(v13_date="", v12_date=""):
+        """Return a mock for _get_schema_config_version_migration_date_from_backup."""
+        def _inner(self_inner, sc_version):
+            return {"v13": v13_date, "v12": v12_date}.get(sc_version, "")
+        return _inner
+
     def test_fresh_install_no_backup_uses_today(self):
         """GIVEN a fresh install with no backup config and no peer v13 date.
 
@@ -582,8 +590,6 @@ class TestTsdbVersionsMigrationDates(unittest.TestCase):
             dates = charm._tsdb_versions_migration_dates  # type: ignore
             v13_entries = [d for d in dates if d["version"] == "v13"]
             self.assertEqual(len(v13_entries), 1)
-            import datetime
-
             expected = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")
             self.assertEqual(v13_entries[0]["date"], expected)
 
@@ -596,13 +602,10 @@ class TestTsdbVersionsMigrationDates(unittest.TestCase):
         charm = self.harness.charm
         original_date = "2026-01-15"
 
-        def mock_backup(self_inner, sc_version):
-            return {"v13": original_date, "v12": ""}.get(sc_version, "")
-
         with patch.object(
             type(charm),
             "_get_schema_config_version_migration_date_from_backup",
-            mock_backup,
+            self._mock_backup(v13_date=original_date),
         ):
             dates = charm._tsdb_versions_migration_dates  # type: ignore
             v13_entries = [d for d in dates if d["version"] == "v13"]
@@ -619,13 +622,10 @@ class TestTsdbVersionsMigrationDates(unittest.TestCase):
         self._set_peer_data("fresh_install", "false")
         original_date = "2026-01-15"
 
-        def mock_backup(self_inner, sc_version):
-            return {"v13": original_date, "v12": ""}.get(sc_version, "")
-
         with patch.object(
             type(charm),
             "_get_schema_config_version_migration_date_from_backup",
-            mock_backup,
+            self._mock_backup(v13_date=original_date),
         ):
             dates = charm._tsdb_versions_migration_dates  # type: ignore
             v13_entries = [d for d in dates if d["version"] == "v13"]
@@ -651,8 +651,6 @@ class TestTsdbVersionsMigrationDates(unittest.TestCase):
             dates = charm._tsdb_versions_migration_dates  # type: ignore
             v13_entries = [d for d in dates if d["version"] == "v13"]
             self.assertEqual(len(v13_entries), 1)
-            import datetime
-
             expected = (
                 datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
             ).strftime("%Y-%m-%d")
@@ -688,13 +686,10 @@ class TestTsdbVersionsMigrationDates(unittest.TestCase):
         charm = self.harness.charm
         original_date = "2026-01-15"
 
-        def mock_backup(self_inner, sc_version):
-            return {"v13": original_date, "v12": ""}.get(sc_version, "")
-
         with patch.object(
             type(charm),
             "_get_schema_config_version_migration_date_from_backup",
-            mock_backup,
+            self._mock_backup(v13_date=original_date),
         ):
             charm._tsdb_versions_migration_dates  # type: ignore
             self.assertEqual(self._get_peer_data("v13_migration_date"), original_date)
@@ -740,19 +735,14 @@ class TestTsdbVersionsMigrationDates(unittest.TestCase):
         # Clear any v13 date that may have been set during setUp hooks.
         self._set_peer_data("v13_migration_date", "")
 
-        def mock_backup(self_inner, sc_version):
-            return {"v12": "2025-06-01", "v13": ""}.get(sc_version, "")
-
         with patch.object(
             type(charm),
             "_get_schema_config_version_migration_date_from_backup",
-            mock_backup,
+            self._mock_backup(v12_date="2025-06-01"),
         ):
             dates = charm._tsdb_versions_migration_dates  # type: ignore
             v13_entries = [d for d in dates if d["version"] == "v13"]
             self.assertEqual(len(v13_entries), 1)
-            import datetime
-
             expected = (
                 datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
             ).strftime("%Y-%m-%d")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -550,15 +550,29 @@ class TestTsdbVersionsMigrationDates(unittest.TestCase):
     def tearDown(self):
         self.check_alert_rules_patcher.stop()
 
+    def _set_peer_data(self, key, value):
+        """Write a value into the peer relation app databag."""
+        charm = self.harness.charm
+        peer_rel = charm.model.get_relation("replicas")
+        assert peer_rel is not None
+        peer_rel.data[charm.app][key] = value
+
+    def _get_peer_data(self, key):
+        """Read a value from the peer relation app databag."""
+        charm = self.harness.charm
+        peer_rel = charm.model.get_relation("replicas")
+        assert peer_rel is not None
+        return peer_rel.data[charm.app].get(key, "")
+
     def test_fresh_install_no_backup_uses_today(self):
-        """GIVEN a fresh install with no backup config and no stored v13 date.
+        """GIVEN a fresh install with no backup config and no peer v13 date.
 
         WHEN _tsdb_versions_migration_dates is accessed
         THEN the v13 date should be today.
         """
         charm = self.harness.charm
-        charm._stored.fresh_install = True  # type: ignore
-        charm._stored.v13_migration_date = ""  # type: ignore
+        # Clear any v13 date that may have been set during setUp hooks.
+        self._set_peer_data("v13_migration_date", "")
 
         with patch.object(
             type(charm),
@@ -580,7 +594,6 @@ class TestTsdbVersionsMigrationDates(unittest.TestCase):
         THEN the backup date takes precedence over today.
         """
         charm = self.harness.charm
-        charm._stored.fresh_install = True  # type: ignore
         original_date = "2026-01-15"
 
         def mock_backup(self_inner, sc_version):
@@ -603,7 +616,7 @@ class TestTsdbVersionsMigrationDates(unittest.TestCase):
         THEN the persisted backup date must be used.
         """
         charm = self.harness.charm
-        charm._stored.fresh_install = False  # type: ignore
+        self._set_peer_data("fresh_install", "false")
         original_date = "2026-01-15"
 
         def mock_backup(self_inner, sc_version):
@@ -620,14 +633,15 @@ class TestTsdbVersionsMigrationDates(unittest.TestCase):
             self.assertEqual(v13_entries[0]["date"], original_date)
 
     def test_upgrade_no_backup_uses_tomorrow(self):
-        """GIVEN an upgrade from v11-only with no v13 in backup or stored state.
+        """GIVEN an upgrade from v11-only with no v13 in backup or peer data.
 
         WHEN _tsdb_versions_migration_dates is accessed
         THEN the v13 date should be tomorrow to preserve today's v11/v12 logs.
         """
         charm = self.harness.charm
-        charm._stored.fresh_install = False  # type: ignore
-        charm._stored.v13_migration_date = ""  # type: ignore
+        self._set_peer_data("fresh_install", "false")
+        # Clear any v13 date that may have been set during setUp hooks.
+        self._set_peer_data("v13_migration_date", "")
 
         with patch.object(
             type(charm),
@@ -644,18 +658,17 @@ class TestTsdbVersionsMigrationDates(unittest.TestCase):
             ).strftime("%Y-%m-%d")
             self.assertEqual(v13_entries[0]["date"], expected)
 
-    def test_stored_state_fallback_when_backup_unavailable(self):
-        """GIVEN a v13 date persisted in stored state but the backup file is unavailable.
+    def test_peer_databag_fallback_when_backup_unavailable(self):
+        """GIVEN a v13 date persisted in peer databag but the backup file is unavailable.
 
-        WHEN _tsdb_versions_migration_dates is accessed (e.g. PVC not yet remounted)
-        THEN the stored state date is returned, preventing date drift.
+        WHEN _tsdb_versions_migration_dates is accessed (e.g. PathError)
+        THEN the peer databag date is returned, preventing date drift.
         """
         charm = self.harness.charm
-        charm._stored.fresh_install = False  # type: ignore
         original_date = "2026-01-15"
-        charm._stored.v13_migration_date = original_date  # type: ignore
+        self._set_peer_data("v13_migration_date", original_date)
 
-        # Backup returns "" (e.g. PVC not yet remounted after pod recreation)
+        # Backup returns "" (e.g. PathError during pod recreation)
         with patch.object(
             type(charm),
             "_get_schema_config_version_migration_date_from_backup",
@@ -666,14 +679,13 @@ class TestTsdbVersionsMigrationDates(unittest.TestCase):
             self.assertEqual(len(v13_entries), 1)
             self.assertEqual(v13_entries[0]["date"], original_date)
 
-    def test_backup_syncs_to_stored_state(self):
-        """GIVEN a v13 date in the backup config but not yet in stored state.
+    def test_backup_syncs_to_peer_databag(self):
+        """GIVEN a v13 date in the backup config but not yet in peer databag.
 
         WHEN _tsdb_versions_migration_dates is accessed
-        THEN the backup date is also persisted into stored state for future fallback.
+        THEN the backup date is also persisted into the peer databag for future fallback.
         """
         charm = self.harness.charm
-        charm._stored.v13_migration_date = ""  # type: ignore
         original_date = "2026-01-15"
 
         def mock_backup(self_inner, sc_version):
@@ -685,7 +697,7 @@ class TestTsdbVersionsMigrationDates(unittest.TestCase):
             mock_backup,
         ):
             charm._tsdb_versions_migration_dates  # type: ignore
-            self.assertEqual(charm._stored.v13_migration_date, original_date)  # type: ignore
+            self.assertEqual(self._get_peer_data("v13_migration_date"), original_date)
 
     def test_v13_date_stable_across_config_changed_events(self):
         """GIVEN a fully configured Loki with a v13 date already pushed.
@@ -717,4 +729,46 @@ class TestTsdbVersionsMigrationDates(unittest.TestCase):
                 v13_date_after = sc["from"]
                 break
         self.assertEqual(original_v13_date, v13_date_after)
+
+    def test_v12_in_backup_signals_upgrade_even_without_peer_data(self):
+        """GIVEN no peer data for fresh_install, but backup has a v12 entry.
+
+        WHEN _tsdb_versions_migration_dates is accessed
+        THEN v12 presence signals an upgrade → v13 = tomorrow (not today).
+        """
+        charm = self.harness.charm
+        # Clear any v13 date that may have been set during setUp hooks.
+        self._set_peer_data("v13_migration_date", "")
+
+        def mock_backup(self_inner, sc_version):
+            return {"v12": "2025-06-01", "v13": ""}.get(sc_version, "")
+
+        with patch.object(
+            type(charm),
+            "_get_schema_config_version_migration_date_from_backup",
+            mock_backup,
+        ):
+            dates = charm._tsdb_versions_migration_dates  # type: ignore
+            v13_entries = [d for d in dates if d["version"] == "v13"]
+            self.assertEqual(len(v13_entries), 1)
+            import datetime
+
+            expected = (
+                datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
+            ).strftime("%Y-%m-%d")
+            self.assertEqual(v13_entries[0]["date"], expected)
+
+    def test_upgrade_charm_sets_peer_databag_flag(self):
+        """GIVEN a running charm.
+
+        WHEN upgrade-charm fires
+        THEN fresh_install is set to 'false' in the peer databag.
+        """
+        charm = self.harness.charm
+        # Verify fresh_install is not set before upgrade
+        self.assertEqual(self._get_peer_data("fresh_install"), "")
+
+        charm.on.upgrade_charm.emit()
+
+        self.assertEqual(self._get_peer_data("fresh_install"), "false")
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -526,7 +526,7 @@ class TestAlertRuleBlockedStatus(unittest.TestCase):
 
 
 class TestTsdbVersionsMigrationDates(unittest.TestCase):
-    """Feature: The v13 schema 'from' date must be computed once and then frozen in the backup."""
+    """Feature: The v13 schema 'from' date must be computed once and then frozen."""
 
     @patch("socket.getfqdn", new=lambda *args: "fqdn")
     @k8s_resource_multipatch
@@ -554,6 +554,7 @@ class TestTsdbVersionsMigrationDates(unittest.TestCase):
         """On a truly fresh install (no backup), v13 date should be today."""
         charm = self.harness.charm
         charm._stored.fresh_install = True  # type: ignore
+        charm._stored.v13_migration_date = ""  # type: ignore
 
         with patch.object(
             type(charm),
@@ -607,9 +608,10 @@ class TestTsdbVersionsMigrationDates(unittest.TestCase):
             self.assertEqual(v13_entries[0]["date"], original_date)
 
     def test_upgrade_no_backup_uses_tomorrow(self):
-        """On upgrade from v11-only (no v13 in backup), v13 date should be tomorrow."""
+        """On upgrade from v11-only (no v13 in backup or stored state), v13 date should be tomorrow."""
         charm = self.harness.charm
         charm._stored.fresh_install = False  # type: ignore
+        charm._stored.v13_migration_date = ""  # type: ignore
 
         with patch.object(
             type(charm),
@@ -625,6 +627,41 @@ class TestTsdbVersionsMigrationDates(unittest.TestCase):
                 datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
             ).strftime("%Y-%m-%d")
             self.assertEqual(v13_entries[0]["date"], expected)
+
+    def test_stored_state_fallback_when_backup_unavailable(self):
+        """When the backup file is unavailable, stored state must prevent date drift."""
+        charm = self.harness.charm
+        charm._stored.fresh_install = False  # type: ignore
+        original_date = "2026-01-15"
+        charm._stored.v13_migration_date = original_date  # type: ignore
+
+        # Backup returns "" (e.g. PVC not yet remounted after pod recreation)
+        with patch.object(
+            type(charm),
+            "_get_schema_config_version_migration_date_from_backup",
+            return_value="",
+        ):
+            dates = charm._tsdb_versions_migration_dates  # type: ignore
+            v13_entries = [d for d in dates if d["version"] == "v13"]
+            self.assertEqual(len(v13_entries), 1)
+            self.assertEqual(v13_entries[0]["date"], original_date)
+
+    def test_backup_syncs_to_stored_state(self):
+        """Reading v13 from backup must also persist the date in stored state."""
+        charm = self.harness.charm
+        charm._stored.v13_migration_date = ""  # type: ignore
+        original_date = "2026-01-15"
+
+        def mock_backup(self_inner, sc_version):
+            return {"v13": original_date, "v12": ""}.get(sc_version, "")
+
+        with patch.object(
+            type(charm),
+            "_get_schema_config_version_migration_date_from_backup",
+            mock_backup,
+        ):
+            charm._tsdb_versions_migration_dates  # type: ignore
+            self.assertEqual(charm._stored.v13_migration_date, original_date)  # type: ignore
 
     def test_v13_date_stable_across_config_changed_events(self):
         """The v13 date must not drift when config-changed fires on a later day."""

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -5,9 +5,10 @@ import json
 import textwrap
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 import yaml
-from charms.loki_k8s.v0.loki_push_api import AlertRules, LokiPushApiConsumer
+from charms.loki_k8s.v0.loki_push_api import AlertRules, CosTool, LokiPushApiConsumer
 from cosl import JujuTopology
 from fs.tempfs import TempFS
 from ops.charm import CharmBase
@@ -341,6 +342,17 @@ class TestAlertRuleFormat(unittest.TestCase):
     def setUp(self):
         self.sandbox = TempFS("consumer_rule_files", auto_clean=True)
         self.addCleanup(self.sandbox.close)
+
+        # CosTool uses platform.processor() to locate the cos-tool binary.
+        # On some systems (containers, CI) this returns "" instead of "x86_64",
+        # so the binary isn't found and label injection is silently skipped.
+        # Reset the class-level cache and mock the processor to ensure the
+        # binary is discovered.
+        CosTool._path = None  # type: ignore
+        CosTool._disabled = False  # type: ignore
+        self.processor_patcher = patch("platform.processor", return_value="x86_64")
+        self.processor_patcher.start()
+        self.addCleanup(self.processor_patcher.stop)
 
         alert_rules_path = self.sandbox.getsyspath("/")
 


### PR DESCRIPTION
## Problem

The `_tsdb_versions_migration_dates` property in `src/charm.py` has a date drift bug: when `fresh_install=True`, it **always** returns `datetime.now()` ("today") as the v13 `from` date, **bypassing the backup config entirely**.

Any event that triggers `_configure()` on a subsequent day — pod churn, config-changed, upgrade-charm, etc. — silently shifts the v13 `from` date forward. This makes previously ingested logs inaccessible: Loki tries to look them up via the v11/boltdb index instead of v13/TSDB.

### Concrete failure scenario (no upgrade needed)

1. **Day 1**: Fresh deploy. v13 from = "2026-04-21". Config pushed & backed up.
2. **Day 2**: Pod churns. `pebble-ready` fires → `_configure()`.
   - `fresh_install=True` → early return with v13 from = "2026-04-22"
   - Backup is **never consulted**
   - Day 1 logs indexed under v13/TSDB are now looked up via v11/boltdb → **error**

### StoredState unreliability (K8s pod churn)

Per the [Ops docs](https://ops.readthedocs.io/en/stable/howto/manage-stored-state.html#storing-state-for-the-lifetime-of-the-charm-container-or-machine), `StoredState` persists only for the lifetime of the charm container. When a K8s resource patch applies (or any cause of pod churn), the container is recreated and StoredState is lost. Using StoredState for `fresh_install` and `v13_migration_date` is therefore unreliable as a fallback.

Additionally, a `PathError` on the backup file does not necessarily mean "fresh install" — it could be a transient filesystem issue. Relying on backup absence alone to determine fresh vs upgrade is insufficient.

## Solution

1. **Read backup config first**: The persisted backup on `/loki/chunks/` (persistent storage) is the primary source of truth for migration dates.
2. **Replace StoredState with peer relation databag**: Move `fresh_install` and `v13_migration_date` from `StoredState` to the `replicas` peer relation app databag, which persists for the **lifetime of the application** in the Juju controller DB — surviving pod churns, container recreation, and K8s resource patches.
3. **Dual fresh-vs-upgrade signal**: When computing from scratch, use both the peer databag `fresh_install` flag (set by `_on_upgrade_charm`) and the presence of v12 in the backup as a secondary signal.

### Fallback hierarchy

| Priority | Source | Survives pod churn? |
|----------|--------|-------------------|
| 1. Primary | Backup config on PVC | ✅ (persistent volume) |
| 2. Secondary | Peer relation app databag | ✅ (Juju controller DB) |
| 3. Last resort | Compute from scratch | N/A (first-time only) |

This makes the system **idempotent**: the v13 date is computed exactly once (on first config push) and frozen in both the backup and peer databag. All subsequent calls return the persisted date.

## Changes

- **`src/charm.py`**:
  - Add `_peers`, `_peer_data_get`, `_peer_data_set` helpers for the `replicas` peer relation
  - Move `fresh_install` and `v13_migration_date` from `StoredState` to peer databag
  - `_on_upgrade_charm` writes `fresh_install=false` to peer databag
  - Rewrite `_tsdb_versions_migration_dates` with layered fallback (backup → peer databag → compute)
  - Add INFO logging of schema migration dates for debugging
  - Add WARNING when backup config is missing but chunks directory has data
  - `StoredState` kept only for ephemeral `_stored.status` dict (recalculated every event)
- **`tests/unit/test_charm.py`**: 9 tests for date preservation across pod churns, upgrades, peer databag fallback, and v12 backup signal
- **`tests/unit/test_consumer.py`**: Fix `CosTool` discovery when `platform.processor()` returns empty string

Closes #589
Closes https://github.com/canonical/loki-operators/issues/49
