### PR TITLE
fix: prevent v13 schema misconfiguration on fresh deploy with resource patch

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -329,8 +329,14 @@ class LokiOperatorCharm(CharmBase):
         The flag is stored in the peer relation app databag so it survives pod churns.
         The backup config on persistent storage is the primary safeguard against date drift;
         this flag only matters on the very first config generation after an upgrade.
+
+        We only set the flag if v13 has already been persisted in the peer databag, proving
+        that the initial configuration completed at least once. On a fresh deploy, the
+        KubernetesComputeResourcesPatch may trigger a pod restart that fires upgrade-charm
+        before _configure() ever completes — in that case we must NOT mark it as "not fresh".
         """
-        self._peer_data_set("fresh_install", "false")
+        if self._peer_data_get("v13_migration_date"):
+            self._peer_data_set("fresh_install", "false")
         self._configure()
 
     def _on_certificate_available(self, _):

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -3,6 +3,7 @@
 # See LICENSE file for licensing details.
 """Config builder for Loki Charmed Operator."""
 
+import datetime
 import os
 from typing import Dict, List, Optional
 
@@ -191,10 +192,19 @@ class ConfigBuilder:
         }
 
     @property
+    def _v13_effective_today(self) -> bool:
+        """Check if v13 schema is the currently effective schema (from date <= today)."""
+        today = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")
+        for migration in self.tsdb_versions_migration_dates:
+            if migration["version"] == "v13" and migration["date"] and migration["date"] <= today:
+                return True
+        return False
+
+    @property
     def _limits_config(self) -> dict:
         # Ref: https://grafana.com/docs/loki/latest/configure/#limits_config
         return {
-            "allow_structured_metadata": True,
+            "allow_structured_metadata": self._v13_effective_today,
             # For convenience, we use an integer but Loki takes a float
             "ingestion_rate_mb": float(self.ingestion_rate_mb),
             "ingestion_burst_size_mb": float(self.ingestion_burst_size_mb),

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -753,7 +753,7 @@ class TestTsdbVersionsMigrationDates(unittest.TestCase):
             self.assertEqual(v13_entries[0]["date"], expected)
 
     def test_upgrade_charm_sets_peer_databag_flag(self):
-        """GIVEN a running charm.
+        """GIVEN a running charm with v13 already persisted.
 
         WHEN upgrade-charm fires
         THEN fresh_install is set to 'false' in the peer databag.
@@ -761,8 +761,104 @@ class TestTsdbVersionsMigrationDates(unittest.TestCase):
         charm = self.harness.charm
         # Verify fresh_install is not set before upgrade
         self.assertEqual(self._get_peer_data("fresh_install"), "")
+        # Verify v13_migration_date IS set (from setUp's initial hooks)
+        self.assertNotEqual(self._get_peer_data("v13_migration_date"), "")
 
         charm.on.upgrade_charm.emit()
 
         self.assertEqual(self._get_peer_data("fresh_install"), "false")
+
+    def test_upgrade_charm_does_not_set_flag_before_initial_configure(self):
+        """GIVEN a fresh deploy where upgrade-charm fires before _configure() completes.
+
+        This simulates the scenario where KubernetesComputeResourcesPatch triggers a
+        pod restart before the initial configuration is written (no backup, no peer v13).
+
+        WHEN upgrade-charm fires with no v13 in peer databag
+        THEN fresh_install must NOT be set to 'false', so the subsequent _configure()
+        correctly computes v13 = today (fresh install logic).
+        """
+        charm = self.harness.charm
+        # Simulate: v13 was never persisted (resource patch restart before initial config)
+        self._set_peer_data("v13_migration_date", "")
+        self._set_peer_data("fresh_install", "")
+
+        with patch.object(
+            type(charm),
+            "_get_schema_config_version_migration_date_from_backup",
+            return_value="",
+        ):
+            # Emit upgrade-charm: since v13_migration_date is empty,
+            # the handler must NOT set fresh_install = "false"
+            charm.on.upgrade_charm.emit()
+
+        # fresh_install must remain unset — this is still a fresh install
+        self.assertEqual(self._get_peer_data("fresh_install"), "")
+
+        # Now simulate _configure() completing (e.g. after pebble-ready on new pod)
+        # The v13 date should be today (fresh install logic, not tomorrow/upgrade logic)
+        with patch.object(
+            type(charm),
+            "_get_schema_config_version_migration_date_from_backup",
+            return_value="",
+        ):
+            dates = charm._tsdb_versions_migration_dates  # type: ignore
+            v13_entries = [d for d in dates if d["version"] == "v13"]
+            self.assertEqual(len(v13_entries), 1)
+            expected = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")
+            self.assertEqual(v13_entries[0]["date"], expected)
+
+    def test_allow_structured_metadata_false_when_v13_is_future(self):
+        """GIVEN a config where v13 starts tomorrow.
+
+        WHEN the config is built
+        THEN allow_structured_metadata must be false to avoid Loki rejecting the config.
+        """
+        from config_builder import ConfigBuilder
+
+        tomorrow = (
+            datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
+        ).strftime("%Y-%m-%d")
+
+        config = ConfigBuilder(
+            instance_addr="localhost",
+            alertmanager_url="",
+            external_url="http://localhost:3100",
+            ingestion_rate_mb=4,
+            ingestion_burst_size_mb=6,
+            retention_period=30,
+            http_tls=False,
+            tsdb_versions_migration_dates=[{"version": "v13", "date": tomorrow}],
+            reporting_enabled=True,
+            grafana_external_url=None,
+            datasource_uid="test-uid",
+        ).build()
+
+        self.assertFalse(config["limits_config"]["allow_structured_metadata"])
+
+    def test_allow_structured_metadata_true_when_v13_is_today(self):
+        """GIVEN a config where v13 starts today.
+
+        WHEN the config is built
+        THEN allow_structured_metadata must be true.
+        """
+        from config_builder import ConfigBuilder
+
+        today = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")
+
+        config = ConfigBuilder(
+            instance_addr="localhost",
+            alertmanager_url="",
+            external_url="http://localhost:3100",
+            ingestion_rate_mb=4,
+            ingestion_burst_size_mb=6,
+            retention_period=30,
+            http_tls=False,
+            tsdb_versions_migration_dates=[{"version": "v13", "date": today}],
+            reporting_enabled=True,
+            grafana_external_url=None,
+            datasource_uid="test-uid",
+        ).build()
+
+        self.assertTrue(config["limits_config"]["allow_structured_metadata"])
 


### PR DESCRIPTION
## Problem

PR #591 fixed the v13 schema date drift bug, but a fresh deploy still fails when `KubernetesComputeResourcesPatch` triggers a StatefulSet rolling restart. The restarted pod fires `upgrade-charm` **before** the initial `_configure()` ever wrote a config or backup, causing Loki to reject its own config:

```
CONFIG ERROR: schema v13 is required to store Structured Metadata and use native OTLP ingestion,
your schema version is v11.
```

**Observed in CI:**
- https://github.com/canonical/prometheus-k8s-operator/actions/runs/25161392333/job/73759931357?pr=798
- https://github.com/canonical/alertmanager-k8s-operator/actions/runs/25159931916/job/73760348120?pr=407

### Why it happens

```mermaid
sequenceDiagram
    participant J as Juju
    participant P1 as Pod (original)
    participant K8s
    participant P2 as Pod (new)

    Note over P1: fresh_install = "" (unset, treated as true)<br/>No config pushed yet, Loki not started

    J->>P1: install → config-changed
    P1->>K8s: ResourcesPatch applies requests (cpu/mem)
    J->>P1: pebble-ready → _configure()
    P1--xP1: is_ready()=False (pod resources ≠ patched spec)<br/>_configure() returns early<br/>NO config pushed, NO backup written, Loki never starts

    Note over P1: fresh_install still "" ✓<br/>v13_migration_date still "" (never computed)

    K8s->>P1: terminate (rolling restart)
    K8s->>P2: create (matches patched spec)

    Note over P2: fresh_install still "" ✓ (peer databag survives)

    J->>P2: upgrade-charm → _on_upgrade_charm()
    P2->>P2: _peer_data_set("fresh_install", "false") ← BUG
    Note over P2: fresh_install = "false" ✗<br/>Wrongly thinks this is an upgrade, not a fresh install!

    P2->>P2: _configure() runs for the FIRST time successfully
    P2->>P2: No backup, no peer v13 → computes from scratch
    P2->>P2: fresh_install="false" → is_fresh=False → v13 from = tomorrow

    Note over P2: Config pushed:<br/>v11/boltdb-shipper active TODAY<br/>v13/tsdb starts TOMORROW<br/>allow_structured_metadata = true

    P2->>P2: Loki 3.7.1 startup validation
    P2--xP2: REJECTS config ❌<br/>allow_structured_metadata=true requires v13/tsdb<br/>but today's active schema is v11/boltdb-shipper
```

The root cause: `_on_upgrade_charm` unconditionally marks `fresh_install="false"`, but on a fresh deploy with a resource patch restart, the initial configuration was never completed — so the charm incorrectly uses upgrade logic (v13=tomorrow) instead of fresh-install logic (v13=today). Loki never starts; it fails at startup config validation.

## Fix

**1. Guard `fresh_install` flag** (`src/charm.py`): Only set `fresh_install="false"` if `v13_migration_date` already exists in the peer databag, proving the initial configuration completed at least once.

**2. Conditional `allow_structured_metadata`** (`src/config_builder.py`): Set it based on whether v13 is the currently effective schema (from date ≤ today). This is a safety net — even if the date logic has edge cases, Loki will never reject the config.

**3. Tests** (`tests/unit/test_charm.py`): 3 new tests for the fresh-deploy + resource-patch scenario and the conditional `allow_structured_metadata` logic. All 83 unit tests pass.

### Known limitation: `allow_structured_metadata` gap on real upgrades

On a real upgrade, v13 is correctly set to tomorrow to preserve today's v11/v12 logs. Fix 2 will set `allow_structured_metadata: false` in the config for that day, since v13 is not yet effective. However, no charm event is automatically scheduled for when v13 becomes active the next day — meaning structured metadata remains disabled until any other Juju event (config-changed, relation event, pod churn, etc.) triggers `_configure()` and rewrites the config with `allow_structured_metadata: true`.

A possible solution would be to run a Pebble check that detects when v13 is in effect and ensures `allow_structured_metadata` is set to `true`, triggering a config rewrite without depending on an external Juju event.
