### PR TITLE
fix: update xfail for workload tracing itest

### DIFF
--- a/tests/integration/test_workload_tracing.py
+++ b/tests/integration/test_workload_tracing.py
@@ -2,8 +2,8 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from datetime import datetime
 import logging
+from datetime import date
 from pathlib import Path
 
 import pytest
@@ -32,7 +32,7 @@ async def test_setup_env(ops_test):
 
 # Xfailing the test until the expected resolution date of the issue: https://github.com/canonical/loki-operators/issues/59
 # Using strict=True to ensure that the test will start failing if it starts passing before the expected date, which would indicate that the underlying issue has been resolved.
-@pytest.mark.xfail(datetime.date.today() < datetime.date(2026, 5, 15), reason="expected to fail until 2026-05-15", strict=True)
+@pytest.mark.xfail(date.today() < date(2026, 5, 19), reason="expected to fail until 2026-05-19", strict=True)
 async def test_workload_tracing_is_present(ops_test, loki_charm, cos_channel):
     # Deploy a Tempo cluster
     minio_user = "accesskey"

--- a/tests/integration/test_workload_tracing.py
+++ b/tests/integration/test_workload_tracing.py
@@ -2,6 +2,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+from datetime import datetime
 import logging
 from pathlib import Path
 
@@ -29,8 +30,9 @@ loki_resources = {
 async def test_setup_env(ops_test):
     await ops_test.model.set_config({"logging-config": "<root>=WARNING; unit=DEBUG"})
 
-
-@pytest.mark.skip("tracing-relation-joined fails - https://github.com/canonical/cos-coordinated-workers/issues/19")
+# Xfailing the test until the expected resolution date of the issue: https://github.com/canonical/loki-operators/issues/59
+# Using strict=True to ensure that the test will start failing if it starts passing before the expected date, which would indicate that the underlying issue has been resolved.
+@pytest.mark.xfail(datetime.date.today() < datetime.date(2026, 5, 15), reason="expected to fail until 2026-05-15", strict=True)
 async def test_workload_tracing_is_present(ops_test, loki_charm, cos_channel):
     # Deploy a Tempo cluster
     minio_user = "accesskey"


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Related to #604. The workload tracing test has been xfailed which meant the test couldn't catch the workload tracing issue. We'll xfail it until that issue is resolved, which should take roughly 2 weeks from the date of the change.

## Solution
<!-- A summary of the solution addressing the above issue -->


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
