### PR TITLE
feat: TF resources variable

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -30,6 +30,7 @@ No modules.
 | <a name="input_config"></a> [config](#input\_config) | Map of the charm configuration options | `map(string)` | `{}` | no |
 | <a name="input_constraints"></a> [constraints](#input\_constraints) | String listing constraints for this application | `string` | `"arch=amd64"` | no |
 | <a name="input_model_uuid"></a> [model\_uuid](#input\_model\_uuid) | Reference to an existing model resource or data source for the model to deploy to | `string` | n/a | yes |
+| <a name="input_resources"></a> [resources](#input\_resources) | The charm's resources i.e., a resource revision number from CharmHub or a custom OCI image resource | `map(string)` | `{}` | no |
 | <a name="input_revision"></a> [revision](#input\_revision) | Revision number of the charm | `number` | `null` | no |
 | <a name="input_storage_directives"></a> [storage\_directives](#input\_storage\_directives) | Map of storage used by the application, which defaults to 1 GB, allocated by Juju | `map(string)` | `{}` | no |
 | <a name="input_units"></a> [units](#input\_units) | Unit count/scale | `number` | `1` | no |

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3,6 +3,7 @@ resource "juju_application" "loki" {
   config             = var.config
   constraints        = var.constraints
   model_uuid         = var.model_uuid
+  resources          = var.resources
   storage_directives = var.storage_directives
   trust              = true # We always need this variable to be true in order to be able to apply resources limits. 
   units              = var.units

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -35,6 +35,12 @@ variable "model_uuid" {
   type        = string
 }
 
+variable "resources" {
+  description = "The charm's resources i.e., a resource revision number from CharmHub or a custom OCI image resource"
+  type        = map(string)
+  default     = {}
+}
+
 variable "revision" {
   description = "Revision number of the charm"
   type        = number


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
To achieve resource (workload image) pinning, we need to expose the `resources` string map so that the product modules can define this.

## Solution
<!-- A summary of the solution addressing the above issue -->
Add this variable in the juju_application:
- https://registry.terraform.io/providers/juju/juju/1.5.1/docs/resources/application#resources-3
