### PR TITLE
feat: use patched Loki 3.7.1 rock

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -166,7 +166,7 @@ resources:
   loki-image:
     type: oci-image
     description: Loki OCI image
-    upstream-source: docker.io/ubuntu/loki@sha256:dfdf5a4db1116a9111e5222910a8d7b30a44f83a4a1f2d99d97af14c77c43ac8  # renovate: oci-image tag: 3.7-24.04
+    upstream-source: docker.io/ubuntu/loki@sha256:bef622ffc7c09e1217c25954eed22a1e52617cc1921866183d394640e1282d0b  # renovate: oci-image tag: 3.7.1-26.04
   node-exporter-image:
     type: oci-image
     description: Node-exporter OCI image

--- a/tests/integration/test_workload_tracing.py
+++ b/tests/integration/test_workload_tracing.py
@@ -30,9 +30,7 @@ loki_resources = {
 async def test_setup_env(ops_test):
     await ops_test.model.set_config({"logging-config": "<root>=WARNING; unit=DEBUG"})
 
-# Xfailing the test until the expected resolution date of the issue: https://github.com/canonical/loki-operators/issues/59
-# Using strict=True to ensure that the test will start failing if it starts passing before the expected date, which would indicate that the underlying issue has been resolved.
-@pytest.mark.xfail(date.today() < date(2026, 5, 19), reason="expected to fail until 2026-05-19", strict=True)
+
 async def test_workload_tracing_is_present(ops_test, loki_charm, cos_channel):
     # Deploy a Tempo cluster
     minio_user = "accesskey"

--- a/tests/integration/test_workload_tracing.py
+++ b/tests/integration/test_workload_tracing.py
@@ -3,10 +3,8 @@
 # See LICENSE file for licensing details.
 
 import logging
-from datetime import date
 from pathlib import Path
 
-import pytest
 import yaml
 from helpers import (
     get_application_ip,


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Related to #604.
Now that the patched Loki 3.7.1 rock has been released to Docker Hub, we can use that image. Since workload tracing will now work, we don't need to xfail the test.

## Solution
<!-- A summary of the solution addressing the above issue -->


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
