### PR TITLE
fix: set `promtail_binary_zip_url` on `relation_changed` as fallback for reconcile-pattern charms

### DIFF
--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -544,7 +544,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 24
+LIBPATCH = 25
 
 PYDEPS = ["cosl"]
 
@@ -1046,6 +1046,14 @@ class LokiPushApiProvider(Object):
         """
         relation.data[self._charm.unit]["public_address"] = socket.getfqdn() or ""
         self.update_endpoint(relation=relation)
+
+        # Ensure promtail binary URL is set in app data. This is normally done on
+        # relation_joined, but charms using the reconcile pattern may miss that event
+        # if the workload container is not yet ready when the relation is first established.
+        if self._charm.unit.is_leader():
+            if not relation.data[self._charm.app].get("promtail_binary_zip_url"):
+                relation.data[self._charm.app].update(self._promtail_binary_url)
+
         return self._should_update_alert_rules(relation)
 
     @property

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -441,6 +441,37 @@ class TestAppRelationData(unittest.TestCase):
         url = promtail_binaries["amd64"]["url"]
         self.assertTrue(url.startswith("http"))
 
+    def test_promtail_url_set_on_relation_changed_if_missing(self):
+        """Scenario: promtail_binary_zip_url is set on relation_changed as a fallback.
+
+        Charms using the reconcile pattern may miss the relation_joined event if the
+        workload container is not yet ready. In that case, promtail_binary_zip_url
+        must be set on the next relation_changed event.
+
+        Ref: https://github.com/canonical/loki-k8s-operator/issues/615
+        """
+        # GIVEN promtail_binary_zip_url was removed from app data (simulating missed relation_joined)
+        rel_data = self.harness.get_relation_data(self.rel_id, self.harness.charm.app)
+        self.assertIn("promtail_binary_zip_url", rel_data)
+        self.harness.update_relation_data(
+            self.rel_id, self.harness.charm.app.name, {"promtail_binary_zip_url": ""}
+        )
+        rel_data = self.harness.get_relation_data(self.rel_id, self.harness.charm.app)
+        self.assertNotIn("promtail_binary_zip_url", rel_data)
+
+        # WHEN a relation_changed event fires (e.g. consumer updates its metadata)
+        self.harness.update_relation_data(
+            self.rel_id, "consumer", {"metadata": json.dumps(METADATA)}
+        )
+
+        # THEN promtail_binary_zip_url is set again in app data
+        rel_data = self.harness.get_relation_data(self.rel_id, self.harness.charm.app)
+        self.assertIn("promtail_binary_zip_url", rel_data)
+        self.assertNotEqual(rel_data["promtail_binary_zip_url"], "")
+        promtail_binaries = json.loads(rel_data["promtail_binary_zip_url"])
+        url = promtail_binaries["amd64"]["url"]
+        self.assertTrue(url.startswith("http"))
+
 
 class TestAlertRuleBlockedStatus(unittest.TestCase):
     """Ensure that Loki 'keeps' BlockedStatus from alert rules until another rules event."""


### PR DESCRIPTION
# Issue

This PR fixes #615

Charms using the reconcile pattern (the way `opentelemetry-collector-k8s-operator` implements it) never receive `promtail_binary_zip_url` in relation data. This prevents `LogProxyConsumer` clients from downloading promtail, breaking the entire log forwarding pipeline.

Root cause: `promtail_binary_zip_url` is only set in `_on_logging_relation_joined`, but reconcile-pattern charms guard their `__init__` with `can_connect()` checks. When `relation_joined` fires before the workload container is ready, the charm returns early, `LokiPushApiProvider` is never instantiated, and the handler never runs. Subsequent `relation_changed` events do invoke the provider, but never set the URL.

Ref: https://github.com/canonical/opentelemetry-collector-k8s-operator/issues/172


# Solution

Add a fallback in `_process_logging_relation_changed` (called on every `relation_changed` and from `update_endpoint` loops) that sets `promtail_binary_zip_url` in app data if it is missing:

```python
if self._charm.unit.is_leader():
    if not relation.data[self._charm.app].get("promtail_binary_zip_url"):
        relation.data[self._charm.app].update(self._promtail_binary_url)
```
This is idempotent — it only writes when the key is absent, so it has no effect on charms where relation_joined already set it.

# Context

The "reconcile pattern" (opentelemetry-collector-operator flavour) defers all logic to a single `_reconcile()` method and exits early from event handlers if the workload container is not yet connectable. This means one-shot lifecycle events like `relation_joined` are effectively lost. Libraries that set relation data exclusively in `relation_joined` are incompatible with this pattern.


# Testing Instructions

Run unit tests

```shell
tox -e unit -- tests/unit/test_charm.py::TestAppRelationData -v
```


The new test `test_promtail_url_set_on_relation_changed_if_missing` verifies that:

1. After promtail_binary_zip_url is cleared from app data (simulating missed relation_joined)
2. A subsequent relation_changed event restores it with a valid HTTP URL
To verify the fix prevents regression, remove lines 1050-1055 from `lib/charms/loki_k8s/v1/loki_push_api.py` and observe the test fail with:

AssertionError: 'promtail_binary_zip_url' not found in {}

# Upgrade Notes

No upgrade steps required. The fix is purely additive — it fills missing relation data on the next relation_changed event. Existing deployments where promtail_binary_zip_url is already set are unaffected (the conditional check skips the write). Charms consuming the library will pick up the fix on the next charmcraft fetch-lib / update-libs run.