### PR TITLE
feat: filter out invalid rule groups and save valid rules to disk

### DIFF
--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -544,7 +544,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 25
+LIBPATCH = 26
 
 PYDEPS = ["cosl"]
 
@@ -1174,7 +1174,6 @@ class LokiPushApiProvider(Object):
                 try:
                     metadata = json.loads(relation.data[relation.app]["metadata"])
                     identifier = JujuTopology.from_dict(metadata).identifier
-                    alerts[identifier] = self._tool.apply_label_matchers(alert_rules)  # type: ignore
 
                 except KeyError as e:
                     logger.debug(
@@ -1195,7 +1194,7 @@ class LokiPushApiProvider(Object):
                     relation.data[self._charm.app]["event"] = json.dumps({"errors": errmsg})
                 continue
 
-            alerts[identifier] = alert_rules
+            alerts[identifier] = self._tool.apply_label_matchers(alert_rules)  # type: ignore
 
         return alerts
 

--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -1188,13 +1188,18 @@ class LokiPushApiProvider(Object):
                 )
                 continue
 
+            alerts[identifier] = self._tool.apply_label_matchers(alert_rules)  # type: ignore
+
             _, errmsg = self._tool.validate_alert_rules(cast(OfficialRuleFileFormat, alert_rules))
             if errmsg:
+                logger.error(f"Invalid alert rule file: {errmsg}")
+                if alerts[identifier]:
+                    del alerts[identifier]
                 if self._charm.unit.is_leader():
                     relation.data[self._charm.app]["event"] = json.dumps({"errors": errmsg})
                 continue
 
-            alerts[identifier] = self._tool.apply_label_matchers(alert_rules)  # type: ignore
+            alerts[identifier] = alert_rules
 
         return alerts
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -854,6 +854,13 @@ class LokiOperatorCharm(CharmBase):
 
         alerts = self.loki_provider.alerts
 
+        # If there aren't any alerts, we can just clean it and move on
+        # The alerts at this point are guaranteed to be valid,
+        # since library filters out invalid rules before returning the dictionary.
+        if alerts:
+            self._generate_alert_rules_files()
+            self._check_alert_rules()
+
         # Check if any relations reported alert rule validation errors.
         # The provider's alerts property writes {"errors": ...} to relation data
         # when cos-tool rejects a rule. The charm should go blocked in that case.
@@ -861,11 +868,6 @@ class LokiOperatorCharm(CharmBase):
             msg = "Invalid alert rules. See debug-log"
             logger.error(msg)
             self._stored.status["rules"] = to_tuple(BlockedStatus(msg))
-
-        # If there aren't any alerts, we can just clean it and move on
-        if alerts:
-            self._generate_alert_rules_files()
-            self._check_alert_rules()
 
     def _has_alert_rule_errors(self) -> bool:
         """Check if any logging relations have alert rule validation errors."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -854,10 +854,42 @@ class LokiOperatorCharm(CharmBase):
 
         alerts = self.loki_provider.alerts
 
+        # Check if any relations reported alert rule validation errors.
+        # The provider's alerts property writes {"errors": ...} to relation data
+        # when cos-tool rejects a rule. The charm should go blocked in that case.
+        if self._has_alert_rule_errors():
+            msg = "Invalid alert rules. See debug-log"
+            logger.error(msg)
+            self._stored.status["rules"] = to_tuple(BlockedStatus(msg))
+
         # If there aren't any alerts, we can just clean it and move on
         if alerts:
             self._generate_alert_rules_files()
             self._check_alert_rules()
+
+    def _has_alert_rule_errors(self) -> bool:
+        """Check if any logging relations have alert rule validation errors."""
+        import json
+
+        if not self.unit.is_leader():
+            return False
+
+        for relation in self.model.relations.get("logging", []):
+            app_data = relation.data.get(self.app)
+            if app_data:
+                event_raw = app_data.get("event", "{}")
+                try:
+                    event_data = json.loads(event_raw)
+                except (json.JSONDecodeError, TypeError):
+                    continue
+                if event_data.get("errors"):
+                    logger.debug(
+                        "Alert rule validation error on relation %s: %s",
+                        relation.id,
+                        event_data["errors"],
+                    )
+                    return True
+        return False
 
     def _generate_alert_rules_files(self) -> None:
         """Generate and upload alert rules files.

--- a/src/charm.py
+++ b/src/charm.py
@@ -666,6 +666,13 @@ class LokiOperatorCharm(CharmBase):
         self._loki_container.replan()
 
         if isinstance(to_status(self._stored.status["rules"]), BlockedStatus):
+
+            # It's possible that the status of the rules is Blocked due to an alert rule validation error
+            # If that's the case, we want to check if the error is still present.
+            # If there was a transient error (e.g., due to Loki not being ready during a previous check), we want to clear the error and unblock the charm.
+            if self._has_alert_rule_errors():
+                return
+
             # Wait briefly for Loki to come back up and re-check the alert rules
             # in case an upgrade/refresh caused the check to occur when it wasn't
             # ready yet. TODO: use custom pebble notice for "workload ready" event.

--- a/src/charm.py
+++ b/src/charm.py
@@ -854,43 +854,10 @@ class LokiOperatorCharm(CharmBase):
 
         alerts = self.loki_provider.alerts
 
-        # Check if any relations reported alert rule validation errors.
-        # The provider's alerts property writes {"errors": ...} to relation data
-        # when cos-tool rejects a rule. The charm should go blocked in that case.
-        if self._has_alert_rule_errors():
-            msg = "Invalid alert rules. See debug-log"
-            logger.error(msg)
-            self._stored.status["rules"] = to_tuple(BlockedStatus(msg))
-            return
-
         # If there aren't any alerts, we can just clean it and move on
         if alerts:
             self._generate_alert_rules_files()
             self._check_alert_rules()
-
-    def _has_alert_rule_errors(self) -> bool:
-        """Check if any logging relations have alert rule validation errors."""
-        import json
-
-        if not self.unit.is_leader():
-            return False
-
-        for relation in self.model.relations.get("logging", []):
-            app_data = relation.data.get(self.app)
-            if app_data:
-                event_raw = app_data.get("event", "{}")
-                try:
-                    event_data = json.loads(event_raw)
-                except (json.JSONDecodeError, TypeError):
-                    continue
-                if event_data.get("errors"):
-                    logger.debug(
-                        "Alert rule validation error on relation %s: %s",
-                        relation.id,
-                        event_data["errors"],
-                    )
-                    return True
-        return False
 
     def _generate_alert_rules_files(self) -> None:
         """Generate and upload alert rules files.

--- a/src/charm.py
+++ b/src/charm.py
@@ -667,18 +667,16 @@ class LokiOperatorCharm(CharmBase):
 
         if isinstance(to_status(self._stored.status["rules"]), BlockedStatus):
 
-            # It's possible that the status of the rules is Blocked due to an alert rule validation error
-            # If that's the case, we want to check if the error is still present.
-            # If there was a transient error (e.g., due to Loki not being ready during a previous check), we want to clear the error and unblock the charm.
-            if self._has_alert_rule_errors():
-                return
-
-            # Wait briefly for Loki to come back up and re-check the alert rules
-            # in case an upgrade/refresh caused the check to occur when it wasn't
-            # ready yet. TODO: use custom pebble notice for "workload ready" event.
-            time.sleep(2)
-            self._check_alert_rules()
-            return  # TODO: why do we have a return here?
+            # If the status of this charm is blocked due to invalid rules in relation data,
+            # _check_alert_rules will set the status to Active just because the Loki API returned a 200, even though there are
+            # still errors in relation data.
+            # Thus, we will only call _check_alert_rules if there are no invalid alert rules in relation data.
+            if not self._has_alert_rule_errors():
+                # Wait briefly for Loki to come back up and re-check the alert rules
+                # in case an upgrade/refresh caused the check to occur when it wasn't
+                # ready yet. TODO: use custom pebble notice for "workload ready" event.
+                time.sleep(2)
+                self._check_alert_rules()
 
         self.ingress_per_unit.provide_ingress_requirements(
             scheme="https" if self._tls_available else "http", port=self._port

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -4,6 +4,8 @@
 
 from unittest.mock import patch
 
+import yaml
+
 
 def tautology(*_, **__) -> bool:
     return True
@@ -26,3 +28,18 @@ class FakeProcessVersionCheck:
 
     def wait(self):
         return ("v0.1.0", "")
+
+def _written_group_names(context, state_out):
+    """Return alert group names found in rendered Loki rule files."""
+    fs = state_out.get_container("loki").get_filesystem(context)
+    rules_dir = fs.joinpath("loki", "rules", "fake")
+    if not rules_dir.exists():
+        return set()
+
+    rule_files = sorted(path for path in rules_dir.iterdir() if path.is_file())
+    written_group_names = set()
+    for rule_file in rule_files:
+        written_rules = yaml.safe_load(rule_file.read_text())
+        for group in written_rules["groups"]:
+            written_group_names.add(group["name"])
+    return written_group_names

--- a/tests/unit/test_alert_rule_filtering.py
+++ b/tests/unit/test_alert_rule_filtering.py
@@ -8,16 +8,6 @@ from helpers import _written_group_names
 from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Relation, State
 
-
-def _validate_rule_file(rules):
-    """Fail validation if any rule in the relation payload contains the INVALID marker."""
-    for group in rules.get("groups", []):
-        for rule in group.get("rules", []):
-            if "INVALID" in rule.get("expr", ""):
-                return False, "parse error"
-    return True, ""
-
-
 VALID_RELATION = Relation(
     "logging",
     remote_app_name="app-valid",

--- a/tests/unit/test_alert_rule_filtering.py
+++ b/tests/unit/test_alert_rule_filtering.py
@@ -1,0 +1,102 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import json
+from unittest.mock import patch
+
+import pytest
+import yaml
+from ops.testing import Relation, State
+
+
+# For the sake of reducing complexity in this test,
+# we assume that any rule containing the string "INVALID" in its expression
+# is invalid and should cause the entire relation's rules to be rejected.
+def _validate_rule_file(rules):
+    """Fail validation if any rule in the relation payload contains the INVALID marker."""
+    for group in rules.get("groups", []):
+        for rule in group.get("rules", []):
+            if "INVALID" in rule.get("expr", ""):
+                return False, "parse error"
+    return True, ""
+
+
+# Helper function to create a Relation with specified alert rules.
+# The `with_invalid_rule` parameter controls whether one of the rules in the relation is intentionally invalid.
+def _relation(name: str, app_name: str, with_invalid_rule: bool) -> Relation:
+    invalid_expr = 'sum(rate({job="foo"}[5m])) > INVALID'
+    valid_expr_1 = f'sum(rate({{job="{name}"}}[5m])) > 0'
+    valid_expr_2 = f'sum(rate({{job="{name}"}}[10m])) > 0'
+
+    group_rules = [
+        {
+            "alert": f"{name.capitalize()}ValidRuleA",
+            "expr": valid_expr_1,
+            "for": "1m",
+            "labels": {"severity": "warning"},
+            "annotations": {"summary": f"{name}-valid-a"},
+        },
+        {
+            "alert": f"{name.capitalize()}ValidRuleB",
+            "expr": invalid_expr if with_invalid_rule else valid_expr_2,
+            "for": "1m",
+            "labels": {"severity": "warning"},
+            "annotations": {"summary": f"{name}-valid-b"},
+        },
+    ]
+
+    alert_rules = {"groups": [{"name": f"{name}-group", "rules": group_rules}]}
+    metadata = {
+        "model": "test",
+        "model_uuid": "20ce8299-3634-4bef-8bd8-5ace6c8816b4",
+        "application": app_name,
+        "charm_name": f"{app_name}-charm",
+    }
+    return Relation(
+        "logging",
+        remote_app_name=app_name,
+        remote_app_data={"alert_rules": json.dumps(alert_rules), "metadata": json.dumps(metadata)},
+    )
+
+
+@pytest.mark.parametrize(
+    "rel1_invalid, rel2_invalid, expected_group_names",
+    [
+        (False, False, {"rel1-group", "rel2-group"}),
+        (False, True, {"rel1-group"}),
+        (True, True, set()),
+    ],
+)
+@patch("charms.loki_k8s.v1.loki_push_api.CosTool.validate_alert_rules", side_effect=_validate_rule_file)
+@patch("charm.LokiOperatorCharm._check_alert_rules", return_value=None)
+def test_relation_level_filtering(_, __, context, loki_container, rel1_invalid, rel2_invalid, expected_group_names):
+    # Each relation contributes one alert group with two rules.
+    # If any rule in that relation payload is invalid, the whole relation payload is dropped.
+    rel1 = _relation("rel1", "app-one", rel1_invalid)
+    rel2 = _relation("rel2", "app-two", rel2_invalid)
+    state_in = State(relations=[rel1, rel2], containers=[loki_container], leader=True)
+
+    # WHEN a logging relation-changed event is processed
+    state_out = context.run(context.on.relation_changed(rel1), state_in)
+
+    # THEN relation payloads with any invalid rule are dropped, valid relation payloads are kept.
+    fs = state_out.get_container("loki").get_filesystem(context)
+
+    # Loki monolithic stores rules in /loki/rules/fake.
+    rules_dir = fs.joinpath("loki", "rules", "fake")
+    if not rules_dir.exists():
+        # No valid relation payload survived filtering, so no rules directory gets populated.
+        assert expected_group_names == set()
+        return
+
+    rule_files = sorted(path for path in rules_dir.iterdir() if path.is_file())
+    # One file is written per surviving relation payload.
+    assert len(rule_files) == len(expected_group_names)
+
+    written_group_names = set()
+    for rule_file in rule_files:
+        written_rules = yaml.safe_load(rule_file.read_text())
+        for group in written_rules["groups"]:
+            written_group_names.add(group["name"])
+
+    assert written_group_names == expected_group_names

--- a/tests/unit/test_alert_rule_filtering.py
+++ b/tests/unit/test_alert_rule_filtering.py
@@ -4,14 +4,11 @@
 import json
 from unittest.mock import patch
 
-import pytest
-import yaml
-from ops.testing import ActiveStatus, BlockedStatus, Relation, State
+from helpers import _written_group_names
+from ops.model import ActiveStatus, BlockedStatus
+from ops.testing import Relation, State
 
 
-# For the sake of reducing complexity in this test,
-# we assume that any rule containing the string "INVALID" in its expression
-# is invalid and should cause the entire relation's rules to be rejected.
 def _validate_rule_file(rules):
     """Fail validation if any rule in the relation payload contains the INVALID marker."""
     for group in rules.get("groups", []):
@@ -21,93 +18,123 @@ def _validate_rule_file(rules):
     return True, ""
 
 
-# Helper function to create a Relation with specified alert rules.
-# The `with_invalid_rule` parameter controls whether one of the rules in the relation is intentionally invalid.
-def _relation(name: str, app_name: str, with_invalid_rule: bool) -> Relation:
-    invalid_expr = 'sum(rate({job="foo"}[5m])) > INVALID'
-    valid_expr_1 = f'sum(rate({{job="{name}"}}[5m])) > 0'
-    valid_expr_2 = f'sum(rate({{job="{name}"}}[10m])) > 0'
+VALID_RELATION = Relation(
+    "logging",
+    remote_app_name="app-valid",
+    remote_app_data={
+        "alert_rules": json.dumps(
+            {
+                "groups": [
+                    {
+                        "name": "valid-group",
+                        "rules": [
+                            {
+                                "alert": "ValidRuleA",
+                                "expr": 'sum(rate({job="valid"}[5m])) > 0',
+                                "for": "1m",
+                                "labels": {"severity": "warning"},
+                                "annotations": {"summary": "valid-a"},
+                            },
+                            {
+                                "alert": "ValidRuleB",
+                                "expr": 'sum(rate({job="valid"}[10m])) > 0',
+                                "for": "1m",
+                                "labels": {"severity": "warning"},
+                                "annotations": {"summary": "valid-b"},
+                            },
+                        ],
+                    }
+                ]
+            }
+        ),
+        "metadata": json.dumps(
+            {
+                "model": "test",
+                "model_uuid": "20ce8299-3634-4bef-8bd8-5ace6c8816b4",
+                "application": "app-valid",
+                "charm_name": "app-valid-charm",
+            }
+        ),
+    },
+)
 
-    group_rules = [
-        {
-            "alert": f"{name.capitalize()}ValidRuleA",
-            "expr": valid_expr_1,
-            "for": "1m",
-            "labels": {"severity": "warning"},
-            "annotations": {"summary": f"{name}-valid-a"},
-        },
-        {
-            "alert": f"{name.capitalize()}ValidRuleB",
-            "expr": invalid_expr if with_invalid_rule else valid_expr_2,
-            "for": "1m",
-            "labels": {"severity": "warning"},
-            "annotations": {"summary": f"{name}-valid-b"},
-        },
-    ]
+INVALID_RELATION = Relation(
+    "logging",
+    remote_app_name="app-invalid",
+    remote_app_data={
+        "alert_rules": json.dumps(
+            {
+                "groups": [
+                    {
+                        "name": "invalid-group",
+                        "rules": [
+                            {
+                                "alert": "InvalidRuleA",
+                                "expr": 'sum(rate({job="invalid"}[5m])) > INVALID',
+                                "for": "1m",
+                                "labels": {"severity": "warning"},
+                                "annotations": {"summary": "invalid-a"},
+                            },
+                            {
+                                "alert": "InvalidRuleB",
+                                "expr": 'sum(rate({job="invalid"}[10m])) > 0',
+                                "for": "1m",
+                                "labels": {"severity": "warning"},
+                                "annotations": {"summary": "invalid-b"},
+                            },
+                        ],
+                    }
+                ]
+            }
+        ),
+        "metadata": json.dumps(
+            {
+                "model": "test",
+                "model_uuid": "20ce8299-3634-4bef-8bd8-5ace6c8816b4",
+                "application": "app-invalid",
+                "charm_name": "app-invalid-charm",
+            }
+        ),
+    },
+)
 
-    alert_rules = {"groups": [{"name": f"{name}-group", "rules": group_rules}]}
-    metadata = {
-        "model": "test",
-        "model_uuid": "20ce8299-3634-4bef-8bd8-5ace6c8816b4",
-        "application": app_name,
-        "charm_name": f"{app_name}-charm",
-    }
-    return Relation(
-        "logging",
-        remote_app_name=app_name,
-        remote_app_data={"alert_rules": json.dumps(alert_rules), "metadata": json.dumps(metadata)},
+
+def test_valid_relation_only(context, loki_container):
+    # GIVEN one relation with only valid rules
+    state_in = State(relations=[VALID_RELATION], containers=[loki_container], leader=True)
+
+    # WHEN the relation changed event is processed
+    with patch("charm.LokiOperatorCharm._check_alert_rules", return_value=None):
+        state_out = context.run(context.on.relation_changed(VALID_RELATION), state_in)
+
+    # THEN valid rules are written and unit remains active
+    assert _written_group_names(context, state_out) == {"valid-group"}
+    assert isinstance(state_out.unit_status, ActiveStatus)
+
+
+def test_invalid_relation_only(context, loki_container):
+    # GIVEN one relation where at least one rule is invalid
+    state_in = State(relations=[INVALID_RELATION], containers=[loki_container], leader=True)
+
+    # WHEN the relation changed event is processed
+    with patch("charm.LokiOperatorCharm._check_alert_rules", return_value=None):
+        state_out = context.run(context.on.relation_changed(INVALID_RELATION), state_in)
+
+    # THEN invalid relation rules are not written and unit is blocked
+    assert _written_group_names(context, state_out) == set()
+    assert isinstance(state_out.unit_status, BlockedStatus)
+
+
+def test_valid_and_invalid_relations(context, loki_container):
+    # GIVEN one valid relation and one invalid relation
+    state_in = State(
+        relations=[VALID_RELATION, INVALID_RELATION], containers=[loki_container], leader=True
     )
 
+    # WHEN the relation changed event is processed
+    with patch("charm.LokiOperatorCharm._check_alert_rules", return_value=None):
+        state_out = context.run(context.on.relation_changed(VALID_RELATION), state_in)
 
-@pytest.mark.parametrize(
-    "rel1_invalid, rel2_invalid, expected_group_names",
-    [
-        (False, False, {"rel1-group", "rel2-group"}),
-        (False, True, {"rel1-group"}),
-        (True, True, set()),
-    ],
-)
-def test_relation_level_filtering(context, loki_container, rel1_invalid, rel2_invalid, expected_group_names):
-    # Each relation contributes one alert group with two rules.
-    # If any rule in that relation payload is invalid, the whole relation payload is dropped.
-    rel1 = _relation("rel1", "app-one", rel1_invalid)
-    rel2 = _relation("rel2", "app-two", rel2_invalid)
-    state_in = State(relations=[rel1, rel2], containers=[loki_container], leader=True)
-
-    # WHEN a logging relation-changed event is processed
-    with patch(
-        "charms.loki_k8s.v1.loki_push_api.CosTool.validate_alert_rules",
-        side_effect=_validate_rule_file,
-    ), patch("charm.LokiOperatorCharm._check_alert_rules", return_value=None):
-        state_out = context.run(context.on.relation_changed(rel1), state_in)
-
-    # THEN relation payloads with any invalid rule are dropped, valid relation payloads are kept.
-    fs = state_out.get_container("loki").get_filesystem(context)
-
-    # Loki monolithic stores rules in /loki/rules/fake.
-    rules_dir = fs.joinpath("loki", "rules", "fake")
-    if not rules_dir.exists():
-        # No valid relation payload survived filtering, so no rules directory gets populated.
-        assert expected_group_names == set()
-        # the status must be blocked.
-        assert isinstance(state_out.unit_status, BlockedStatus)
-        return
-
-    rule_files = sorted(path for path in rules_dir.iterdir() if path.is_file())
-    # One file is written per surviving relation payload.
-    assert len(rule_files) == len(expected_group_names)
-
-    written_group_names = set()
-    for rule_file in rule_files:
-        written_rules = yaml.safe_load(rule_file.read_text())
-        for group in written_rules["groups"]:
-            written_group_names.add(group["name"])
-
-    assert written_group_names == expected_group_names
-    # If only one file is written, that means the other file contained an invalid rule.
-    # So, we must assert that the charm was correctly blocked in that case.
-    if len(written_group_names) == 1:
-        assert isinstance(state_out.unit_status, BlockedStatus)
-    elif len(written_group_names) == 2:
-        # If both files are written, then no invalid rules were present, so the charm should not be active.
-        assert isinstance(state_out.unit_status, ActiveStatus)
+    # THEN only valid relation rules are written and unit is blocked due to invalid relation
+    assert _written_group_names(context, state_out) == {"valid-group"}
+    assert isinstance(state_out.unit_status, BlockedStatus)

--- a/tests/unit/test_alert_rule_filtering.py
+++ b/tests/unit/test_alert_rule_filtering.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 import yaml
-from ops.testing import Relation, State
+from ops.testing import ActiveStatus, BlockedStatus, Relation, State
 
 
 # For the sake of reducing complexity in this test,
@@ -67,9 +67,7 @@ def _relation(name: str, app_name: str, with_invalid_rule: bool) -> Relation:
         (True, True, set()),
     ],
 )
-@patch("charms.loki_k8s.v1.loki_push_api.CosTool.validate_alert_rules", side_effect=_validate_rule_file)
-@patch("charm.LokiOperatorCharm._check_alert_rules", return_value=None)
-def test_relation_level_filtering(_, __, context, loki_container, rel1_invalid, rel2_invalid, expected_group_names):
+def test_relation_level_filtering(context, loki_container, rel1_invalid, rel2_invalid, expected_group_names):
     # Each relation contributes one alert group with two rules.
     # If any rule in that relation payload is invalid, the whole relation payload is dropped.
     rel1 = _relation("rel1", "app-one", rel1_invalid)
@@ -77,7 +75,11 @@ def test_relation_level_filtering(_, __, context, loki_container, rel1_invalid, 
     state_in = State(relations=[rel1, rel2], containers=[loki_container], leader=True)
 
     # WHEN a logging relation-changed event is processed
-    state_out = context.run(context.on.relation_changed(rel1), state_in)
+    with patch(
+        "charms.loki_k8s.v1.loki_push_api.CosTool.validate_alert_rules",
+        side_effect=_validate_rule_file,
+    ), patch("charm.LokiOperatorCharm._check_alert_rules", return_value=None):
+        state_out = context.run(context.on.relation_changed(rel1), state_in)
 
     # THEN relation payloads with any invalid rule are dropped, valid relation payloads are kept.
     fs = state_out.get_container("loki").get_filesystem(context)
@@ -87,6 +89,8 @@ def test_relation_level_filtering(_, __, context, loki_container, rel1_invalid, 
     if not rules_dir.exists():
         # No valid relation payload survived filtering, so no rules directory gets populated.
         assert expected_group_names == set()
+        # the status must be blocked.
+        assert isinstance(state_out.unit_status, BlockedStatus)
         return
 
     rule_files = sorted(path for path in rules_dir.iterdir() if path.is_file())
@@ -100,3 +104,10 @@ def test_relation_level_filtering(_, __, context, loki_container, rel1_invalid, 
             written_group_names.add(group["name"])
 
     assert written_group_names == expected_group_names
+    # If only one file is written, that means the other file contained an invalid rule.
+    # So, we must assert that the charm was correctly blocked in that case.
+    if len(written_group_names) == 1:
+        assert isinstance(state_out.unit_status, BlockedStatus)
+    elif len(written_group_names) == 2:
+        # If both files are written, then no invalid rules were present, so the charm should not be active.
+        assert isinstance(state_out.unit_status, ActiveStatus)


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes #623.
Related to: https://github.com/canonical/loki-operators/issues/80. Once this PR goes in, the consequent `fetch-lib` action will fix this issue as well. However, let's not close the issue until we've added a unit test in that repo too.

## Solution
<!-- A summary of the solution addressing the above issue -->
We remove the `_has_alert_rule_errors` method. This method used to check whether ANY logging relations had validation errors. If even a single one did, it would set status=blocked. Instead, the desired behaviour is that we first read all rule groups coming from relation data.  Then, the Loki Push API library iterates over each available relation and validates the rule groups. If a group is invalid, it should `continue`, without writing it to the `alerts` object it will eventually return to the charm. 

Now, we filter out invalid rules, save valid rules to disk, and still set blocked to capture the attention of the admin.
## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
Now, both the validation of rules on disk and in databag contribute to setting Blocked status in the charm. The `Blocked` status in this context is purely cosmetic: allowing the charm to operate normally, avoiding a charm (with invalid alert rules) side-effecting in Loki.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
