### PR TITLE
fix: Scenario migration

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -49,7 +49,10 @@ def loki_container():
     return Container(
         "loki",
         can_connect=True,
-        execs={Exec(["update-ca-certificates", "--fresh"], return_code=0)},
+        execs={
+            Exec(["update-ca-certificates", "--fresh"], return_code=0),
+            Exec(["/usr/bin/loki", "-version"], return_code=0, stdout="loki, version 3.14159"),
+        },
         layers={"loki": ops.pebble.Layer({"services": {"loki": {}}})},
         service_statuses={"loki": ops.pebble.ServiceStatus.INACTIVE},
     )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -437,7 +437,7 @@ def test_alert_rule_errors_appropriately_set_state(ctx, loki_container):
     with patch("urllib.request.urlopen") as mock_request, patch.object(
         LokiOperatorCharm, "_update_cert"
     ):
-        # Configure mock to raise HTTPError
+        # GIVEN alert-rules verification fails
         mock_request.side_effect = HTTPError(
             url="http://example.com",
             code=404,
@@ -445,11 +445,28 @@ def test_alert_rule_errors_appropriately_set_state(ctx, loki_container):
             fp=BytesIO(initial_bytes="fubar!".encode()),
             hdrs=HTTPMessage(),
         )
-        state_out = ctx.run(ctx.on.relation_changed(logging_rel), state)
 
-    assert state_out.unit_status == BlockedStatus(
-        "Failed to verify alert rules. Check juju debug-log"
-    )
+        # WHEN a rules-changed event is processed THEN the charm goes blocked
+        state_blocked = ctx.run(ctx.on.relation_changed(logging_rel), state)
+        assert state_blocked.unit_status == BlockedStatus(
+            "Failed to verify alert rules. Check juju debug-log"
+        )
+
+        # WHEN another event fires while verification still fails
+        # THEN the charm stays blocked (the status is "sticky")
+        state_still_blocked = ctx.run(ctx.on.config_changed(), state_blocked)
+        assert state_still_blocked.unit_status == BlockedStatus(
+            "Failed to verify alert rules. Check juju debug-log"
+        )
+
+        # WHEN verification now succeeds and another rules-changed event arrives
+        mock_request.side_effect = None
+        mock_request.return_value = BytesIO(initial_bytes="success".encode())
+        rel = state_still_blocked.get_relation(logging_rel.id)
+        state_recovered = ctx.run(ctx.on.relation_changed(rel), state_still_blocked)
+
+        # THEN the charm recovers to Active
+        assert state_recovered.unit_status == ActiveStatus()
 
 
 def test_loki_connection_errors_on_lifecycle_events_appropriately_clear(ctx, loki_container):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -240,6 +240,9 @@ def test_loki_starts_when_cluster_deployed_without_any_relations(ctx, loki_conta
     command = plan.services["loki"].command
     assert "-config.file=" in command
 
+    # AND the service is running
+    assert container.service_statuses["loki"] == ops.pebble.ServiceStatus.ACTIVE
+
 
 # --- TestDelayedPebbleReady ---
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -125,9 +125,7 @@ def test_on_config_cannot_connect(ctx, loki_container_cannot_connect):
     """Test that charm goes to Maintenance when cannot connect to container."""
     state = State(leader=True, containers=[loki_container_cannot_connect])
 
-    with patch("config_builder.ConfigBuilder.build") as mock_build:
-        mock_build.return_value = {}
-        state_out = ctx.run(ctx.on.config_changed(), state)
+    state_out = ctx.run(ctx.on.config_changed(), state)
 
     # When can't connect, charm stays in Maintenance (exact message may vary)
     assert isinstance(state_out.unit_status, MaintenanceStatus)
@@ -137,10 +135,7 @@ def test_on_config_can_connect(ctx, loki_container):
     """Test that charm goes to Active when connected to container."""
     state = State(leader=True, containers=[loki_container])
 
-    with patch("config_builder.ConfigBuilder.build") as mock_build, patch.object(
-        LokiOperatorCharm, "_update_cert"
-    ):
-        mock_build.return_value = {}
+    with patch.object(LokiOperatorCharm, "_update_cert"):
         state_out = ctx.run(ctx.on.config_changed(), state)
 
     assert state_out.unit_status == ActiveStatus()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -272,6 +272,66 @@ def test_pebble_ready_changes_status_from_waiting_to_active(ctx, loki_container)
         assert state_after.unit_status == ActiveStatus()
 
 
+def test_regular_relation_departed_runs_before_pebble_ready(
+    ctx, loki_container, loki_container_cannot_connect
+):
+    """A relation-departed arriving before pebble-ready must not break the charm."""
+    # GIVEN a logging relation with two consumer units, but pebble is not ready yet
+    logging_rel = Relation(
+        "logging",
+        remote_app_name="consumer-app",
+        remote_app_data={"metadata": "{}", "alert_rules": "{}"},
+        remote_units_data={0: {}, 1: {}},
+    )
+    state_waiting = State(
+        leader=True, containers=[loki_container_cannot_connect], relations=[logging_rel]
+    )
+
+    with patch("charm.LokiOperatorCharm._check_alert_rules", return_value=True), patch(
+        "charm.LokiOperatorCharm._loki_version",
+        new_callable=PropertyMock,
+        return_value="3.14159",
+    ), patch.object(LokiOperatorCharm, "_update_cert"):
+        # WHEN relation-departed fires before pebble-ready (must not raise)
+        state_early = ctx.run(
+            ctx.on.relation_departed(logging_rel, remote_unit=1), state_waiting
+        )
+
+        # THEN the charm converges to Active once pebble becomes ready
+        state_with_pebble = replace(state_early, containers=frozenset([loki_container]))
+        state_after = ctx.run(ctx.on.pebble_ready(loki_container), state_with_pebble)
+        assert state_after.unit_status == ActiveStatus()
+
+
+def test_regular_relation_broken_runs_before_pebble_ready(
+    ctx, loki_container, loki_container_cannot_connect
+):
+    """A relation-broken arriving before pebble-ready must not break the charm."""
+    # GIVEN a logging relation, but pebble is not ready yet
+    logging_rel = Relation(
+        "logging",
+        remote_app_name="consumer-app",
+        remote_app_data={"metadata": "{}", "alert_rules": "{}"},
+        remote_units_data={0: {}, 1: {}},
+    )
+    state_waiting = State(
+        leader=True, containers=[loki_container_cannot_connect], relations=[logging_rel]
+    )
+
+    with patch("charm.LokiOperatorCharm._check_alert_rules", return_value=True), patch(
+        "charm.LokiOperatorCharm._loki_version",
+        new_callable=PropertyMock,
+        return_value="3.14159",
+    ), patch.object(LokiOperatorCharm, "_update_cert"):
+        # WHEN relation-broken fires before pebble-ready (must not raise)
+        state_early = ctx.run(ctx.on.relation_broken(logging_rel), state_waiting)
+
+        # THEN the charm converges to Active once pebble becomes ready
+        state_with_pebble = replace(state_early, containers=frozenset([loki_container]))
+        state_after = ctx.run(ctx.on.pebble_ready(loki_container), state_with_pebble)
+        assert state_after.unit_status == ActiveStatus()
+
+
 # --- TestAppRelationData ---
 
 

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -189,7 +189,7 @@ def reload_context(alert_rules_sandbox):
         "name": "reload-consumer",
         "requires": {"logging": {"interface": "loki_push_api"}},
     }
-    return Context(ReloadConsumerCharm, meta=meta), alert_rules_sandbox
+    return Context(ReloadConsumerCharm, meta=meta)
 
 
 NO_ALERTS = json.dumps({})
@@ -198,7 +198,7 @@ ALERT = yaml.safe_dump({"alert": "free_standing", "expr": "avg(some_vector[5m]) 
 
 def test_reload_when_dir_is_still_empty_changes_nothing(reload_context):
     """Scenario: The reload method is called when the alerts dir is still empty."""
-    ctx, sandbox = reload_context
+    ctx = reload_context
     logging_rel = Relation("logging", remote_app_name="loki", remote_units_data={0: {}})
     state = State(leader=True, relations=[logging_rel])
 
@@ -218,9 +218,9 @@ def test_reload_when_dir_is_still_empty_changes_nothing(reload_context):
         assert relation.data[charm.app].get("alert_rules") == NO_ALERTS
 
 
-def test_reload_after_dir_is_populated_updates_relation_data(reload_context):
+def test_reload_after_dir_is_populated_updates_relation_data(reload_context, alert_rules_sandbox):
     """Scenario: The reload method is called after some alert files are added."""
-    ctx, sandbox = reload_context
+    ctx = reload_context
     logging_rel = Relation("logging", remote_app_name="loki", remote_units_data={0: {}})
     state = State(leader=True, relations=[logging_rel])
 
@@ -234,7 +234,7 @@ def test_reload_after_dir_is_populated_updates_relation_data(reload_context):
         assert relation.data[charm.app].get("alert_rules") == NO_ALERTS
 
         # WHEN some rule files are added to the alerts dir
-        sandbox.writetext("alert.rule", ALERT)
+        alert_rules_sandbox.writetext("alert.rule", ALERT)
 
         # AND the reload method is called
         charm.loki_consumer._reinitialize_alert_rules()
@@ -243,9 +243,9 @@ def test_reload_after_dir_is_populated_updates_relation_data(reload_context):
         assert relation.data[charm.app].get("alert_rules") != NO_ALERTS
 
 
-def test_reload_after_dir_is_emptied_updates_relation_data(reload_context):
+def test_reload_after_dir_is_emptied_updates_relation_data(reload_context, alert_rules_sandbox):
     """Scenario: The reload method is called after all the loaded alert files are removed."""
-    ctx, sandbox = reload_context
+    ctx = reload_context
     logging_rel = Relation("logging", remote_app_name="loki", remote_units_data={0: {}})
     state = State(leader=True, relations=[logging_rel])
 
@@ -256,12 +256,12 @@ def test_reload_after_dir_is_emptied_updates_relation_data(reload_context):
         assert relation
 
         # GIVEN alert files are present and reload has populated the relation data
-        sandbox.writetext("alert.rule", ALERT)
+        alert_rules_sandbox.writetext("alert.rule", ALERT)
         charm.loki_consumer._reinitialize_alert_rules()
         assert relation.data[charm.app].get("alert_rules") != NO_ALERTS
 
         # WHEN all rule files are deleted from the alerts dir
-        sandbox.remove("alert.rule")
+        alert_rules_sandbox.remove("alert.rule")
 
         # AND the reload method is called
         charm.loki_consumer._reinitialize_alert_rules()
@@ -270,10 +270,10 @@ def test_reload_after_dir_is_emptied_updates_relation_data(reload_context):
         assert relation.data[charm.app].get("alert_rules") == NO_ALERTS
 
 
-def test_reload_after_dir_itself_removed_updates_relation_data(reload_context):
+def test_reload_after_dir_itself_removed_updates_relation_data(reload_context, alert_rules_sandbox):
     """Scenario: The reload method is called after the alerts dir doesn't exist anymore."""
-    ctx, sandbox = reload_context
-    alert_rules_path = sandbox.getsyspath("/")
+    ctx = reload_context
+    alert_rules_path = alert_rules_sandbox.getsyspath("/")
     logging_rel = Relation("logging", remote_app_name="loki", remote_units_data={0: {}})
     state = State(leader=True, relations=[logging_rel])
 
@@ -284,7 +284,7 @@ def test_reload_after_dir_itself_removed_updates_relation_data(reload_context):
         assert relation
 
         # GIVEN alert files are present and reload has populated the relation data
-        sandbox.writetext("alert.rule", ALERT)
+        alert_rules_sandbox.writetext("alert.rule", ALERT)
         charm.loki_consumer._reinitialize_alert_rules()
         assert relation.data[charm.app].get("alert_rules") != NO_ALERTS
 

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 
 import json
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import patch
 
@@ -79,9 +80,9 @@ def test_on_logging_relation_changed_no_unit(consumer_context):
     consumer_context.run(consumer_context.on.relation_changed(logging_rel), state)
 
 
-def test_3_provider_units_related_scaled_down_to_0(consumer_context):
-    """Test with 3 provider units, then scale down to 0."""
-    # Create relation with 3 loki units
+def test_multiple_provider_units_related(consumer_context):
+    """Test with 3 provider units."""
+    # GIVEN 3 provider units are related
     logging_rel = Relation(
         "logging",
         remote_app_name="loki",
@@ -92,10 +93,9 @@ def test_3_provider_units_related_scaled_down_to_0(consumer_context):
         },
     )
     state = State(leader=True, relations=[logging_rel])
-
     with consumer_context(consumer_context.on.relation_changed(logging_rel), state) as mgr:
         charm = mgr.charm
-        # Check we have 3 Loki endpoints
+        # THEN we have 3 Loki endpoints
         assert len(charm.loki_consumer.loki_endpoints) == 3
 
         # Check each endpoint is a dict, has a "url" key and starts with "http://"

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 
 import json
-from dataclasses import replace
+import shutil
 from pathlib import Path
 from unittest.mock import patch
 
@@ -177,79 +177,103 @@ def test_reload_when_dir_is_still_empty_changes_nothing(reload_context):
     logging_rel = Relation("logging", remote_app_name="loki", remote_units_data={0: {}})
     state = State(leader=True, relations=[logging_rel])
 
-    # Run relation_joined first to initialize
-    state_out = ctx.run(ctx.on.relation_joined(logging_rel), state)
+    with ctx(ctx.on.relation_joined(logging_rel), state) as mgr:
+        mgr.run()
+        charm = mgr.charm
+        relation = charm.model.get_relation("logging")
+        assert relation
 
-    # Check that alert_rules is empty (or an empty dict serialized)
-    rel = state_out.get_relation(logging_rel.id)
-    alert_rules = rel.local_app_data.get("alert_rules", "{}")
-    assert alert_rules == "{}" or json.loads(alert_rules) == {}
+        # GIVEN relation data contains no alerts
+        assert relation.data[charm.app].get("alert_rules") == NO_ALERTS
+
+        # WHEN the reload method is called
+        charm.loki_consumer._reinitialize_alert_rules()
+
+        # THEN relation data is unchanged
+        assert relation.data[charm.app].get("alert_rules") == NO_ALERTS
 
 
 def test_reload_after_dir_is_populated_updates_relation_data(reload_context):
     """Scenario: The reload method is called after some alert files are added."""
     ctx, sandbox = reload_context
-
-    # WHEN some rule files are added to the alerts dir BEFORE charm runs
-    sandbox.writetext("alert.rule", ALERT)
-
     logging_rel = Relation("logging", remote_app_name="loki", remote_units_data={0: {}})
     state = State(leader=True, relations=[logging_rel])
 
-    # Run relation_joined which will load the alert rules
-    state_out = ctx.run(ctx.on.relation_joined(logging_rel), state)
+    with ctx(ctx.on.relation_joined(logging_rel), state) as mgr:
+        mgr.run()
+        charm = mgr.charm
+        relation = charm.model.get_relation("logging")
+        assert relation
 
-    # THEN relation data should have the alert rules
-    rel = state_out.get_relation(logging_rel.id)
-    alert_rules = rel.local_app_data.get("alert_rules", "{}")
-    assert alert_rules != NO_ALERTS
-    assert json.loads(alert_rules) != {}
+        # GIVEN relation data contains no alerts
+        assert relation.data[charm.app].get("alert_rules") == NO_ALERTS
+
+        # WHEN some rule files are added to the alerts dir
+        sandbox.writetext("alert.rule", ALERT)
+
+        # AND the reload method is called
+        charm.loki_consumer._reinitialize_alert_rules()
+
+        # THEN relation data is updated
+        assert relation.data[charm.app].get("alert_rules") != NO_ALERTS
 
 
-def test_reload_after_dir_is_emptied_updates_relation_data():
-    """Scenario: The reload method is called after all the loaded alert files are removed.
+def test_reload_after_dir_is_emptied_updates_relation_data(reload_context):
+    """Scenario: The reload method is called after all the loaded alert files are removed."""
+    ctx, sandbox = reload_context
+    logging_rel = Relation("logging", remote_app_name="loki", remote_units_data={0: {}})
+    state = State(leader=True, relations=[logging_rel])
 
-    This test verifies that when alert rule files are removed, subsequent events
-    reflect the empty state correctly.
-    """
-    # Create a fresh sandbox for this test
-    sandbox = TempFS("rule_files_empty_test", auto_clean=True)
+    with ctx(ctx.on.relation_joined(logging_rel), state) as mgr:
+        mgr.run()
+        charm = mgr.charm
+        relation = charm.model.get_relation("logging")
+        assert relation
+
+        # GIVEN alert files are present and reload has populated the relation data
+        sandbox.writetext("alert.rule", ALERT)
+        charm.loki_consumer._reinitialize_alert_rules()
+        assert relation.data[charm.app].get("alert_rules") != NO_ALERTS
+
+        # WHEN all rule files are deleted from the alerts dir
+        sandbox.remove("alert.rule")
+
+        # AND the reload method is called
+        charm.loki_consumer._reinitialize_alert_rules()
+
+        # THEN relation data is empty again
+        assert relation.data[charm.app].get("alert_rules") == NO_ALERTS
+
+
+def test_reload_after_dir_itself_removed_updates_relation_data(reload_context):
+    """Scenario: The reload method is called after the alerts dir doesn't exist anymore."""
+    ctx, sandbox = reload_context
     alert_rules_path = sandbox.getsyspath("/")
-
-    class EmptyReloadConsumerCharm(CharmBase):
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args)
-            self._port = 3100
-            self.loki_consumer = LokiPushApiConsumer(
-                self,
-                alert_rules_path=alert_rules_path,
-                recursive=True,
-                skip_alert_topology_labeling=True,
-            )
-
-    meta = {
-        "name": "reload-consumer",
-        "requires": {"logging": {"interface": "loki_push_api"}},
-    }
-    ctx = Context(EmptyReloadConsumerCharm, meta=meta)
-
-    # First populate the sandbox
-    sandbox.writetext("alert.rule", ALERT)
-
     logging_rel = Relation("logging", remote_app_name="loki", remote_units_data={0: {}})
     state = State(leader=True, relations=[logging_rel])
 
-    # First run with alert rules
-    state_with_alerts = ctx.run(ctx.on.relation_joined(logging_rel), state)
+    with ctx(ctx.on.relation_joined(logging_rel), state) as mgr:
+        mgr.run()
+        charm = mgr.charm
+        relation = charm.model.get_relation("logging")
+        assert relation
 
-    # Verify alerts were set
-    rel = state_with_alerts.get_relation(logging_rel.id)
-    assert rel.local_app_data.get("alert_rules") != NO_ALERTS
-    assert json.loads(rel.local_app_data["alert_rules"]) != {}
+        # GIVEN alert files are present and reload has populated the relation data
+        sandbox.writetext("alert.rule", ALERT)
+        charm.loki_consumer._reinitialize_alert_rules()
+        assert relation.data[charm.app].get("alert_rules") != NO_ALERTS
 
-    # Clean up
-    sandbox.clean()
-    sandbox.close()
+        # WHEN the alerts dir itself is deleted
+        shutil.rmtree(alert_rules_path)
+
+        # AND the reload method is called
+        charm.loki_consumer._reinitialize_alert_rules()
+
+        # THEN relation data is empty again (and no error is raised)
+        assert relation.data[charm.app].get("alert_rules") == NO_ALERTS
+
+    # Recreate the dir so the sandbox fixture can tear down cleanly.
+    Path(alert_rules_path).mkdir(parents=True, exist_ok=True)
 
 
 # --- TestAlertRuleNaming ---

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -3,6 +3,7 @@
 
 import json
 import shutil
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import patch
 
@@ -114,9 +115,21 @@ def test_on_upgrade_charm_endpoint_joined_event_fired_for_leader(consumer_contex
     )
     state = State(leader=True, relations=[logging_rel])
 
+    # WHEN a provider unit joins THEN endpoint_joined fires once
     with consumer_context(consumer_context.on.relation_joined(logging_rel), state) as mgr:
-        mgr.run()
+        state = mgr.run()
         assert mgr.charm._stored.endpoint_events == 1
+
+    # WHEN the provider then publishes its push-api endpoint (relation-changed)
+    rel = replace(
+        state.get_relation(logging_rel.id),
+        remote_app_data={"data": '{"loki_push_api": "http://10.1.2.3:3100/loki/api/v1/push"}'},
+    )
+    state = replace(state, relations={rel})
+    with consumer_context(consumer_context.on.relation_changed(rel), state) as mgr:
+        mgr.run()
+        # THEN endpoint_joined fires again
+        assert mgr.charm._stored.endpoint_events == 2
 
 
 def test_on_upgrade_charm_endpoint_joined_event_fired_for_follower(consumer_context):
@@ -128,9 +141,21 @@ def test_on_upgrade_charm_endpoint_joined_event_fired_for_follower(consumer_cont
     )
     state = State(leader=False, relations=[logging_rel])
 
+    # WHEN a provider unit joins THEN endpoint_joined fires once
     with consumer_context(consumer_context.on.relation_joined(logging_rel), state) as mgr:
-        mgr.run()
+        state = mgr.run()
         assert mgr.charm._stored.endpoint_events == 1
+
+    # WHEN the provider then publishes its push-api endpoint (relation-changed)
+    rel = replace(
+        state.get_relation(logging_rel.id),
+        remote_app_data={"data": '{"loki_push_api": "http://10.1.2.3:3100/loki/api/v1/push"}'},
+    )
+    state = replace(state, relations={rel})
+    with consumer_context(consumer_context.on.relation_changed(rel), state) as mgr:
+        mgr.run()
+        # THEN endpoint_joined fires again
+        assert mgr.charm._stored.endpoint_events == 2
 
 
 # --- TestReloadAlertRules ---

--- a/tests/unit/test_log_proxy_consumer.py
+++ b/tests/unit/test_log_proxy_consumer.py
@@ -18,7 +18,7 @@ from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.pebble import PathError
 from ops.testing import Context
-from scenario import Container, Model, Relation, State
+from scenario import Container, Model, Relation, Resource, State
 
 LOG_FILES = ["/var/log/apache2/access.log", "/var/log/alternatives.log", "/var/log/test.log"]
 
@@ -396,20 +396,41 @@ def consumer_with_resource_context():
     return Context(ConsumerCharmWithPromtailResource, meta=CONSUMER_WITH_RESOURCE_META)
 
 
-def test_fetch_promtail_from_attached_resource(consumer_with_resource_context, loki_container, promtail_container):
-    """Test that promtail detection works with resource metadata."""
+def test_fetch_promtail_from_attached_resource(
+    consumer_with_resource_context, loki_container, promtail_container, caplog, tmp_path
+):
+    """Scenario: the promtail binary is provided via an attached juju resource.
+
+    Note: the original Harness test also asserted ``_promtail_attached_as_resource``
+    is False before attaching. Scenario requires every *declared* resource to be
+    present in ``State.resources`` (a missing one raises ``RuntimeError``, not the
+    ``ModelError`` the lib catches), so the "declared but unattached" state is not
+    representable here; we exercise the attached path, which is the feature itself.
+    """
+    # GIVEN the "promtail-bin" resource (hardcoded name in the lib) is attached
+    resource_file = tmp_path / PROMTAIL_INFO["filename"]
+    resource_file.write_text("somecontent")
     state = State(
         leader=True,
         containers=[loki_container, promtail_container],
+        resources=[Resource(name="promtail-bin", path=resource_file)],
         model=Model(name="MODEL", uuid="20ce8299-3634-4bef-8bd8-5ace6c8816b4"),
     )
 
-    # Just test that the charm initializes correctly with resource metadata
-    # The actual resource attachment testing requires proper resource mocking
-    with consumer_with_resource_context(consumer_with_resource_context.on.start(), state) as mgr:
+    with consumer_with_resource_context(
+        consumer_with_resource_context.on.start(), state
+    ) as mgr:
         charm = mgr.charm
-        # Verify that the log_proxy exists and the resource name is expected
-        assert charm.log_proxy._promtail_resource_name == "promtail-bin"
+        # THEN the lib detects the attached resource
+        assert charm.log_proxy._promtail_attached_as_resource is True
+
+        # AND pushing it to the workload reports it came from a resource
+        binary_path = os.path.join("/tmp", PROMTAIL_INFO["filename"])
+        with caplog.at_level("INFO", logger="charms.loki_k8s.v0.loki_push_api"):
+            assert charm.log_proxy._push_promtail_if_attached(binary_path) is True
+        assert (
+            "Promtail binary file has been obtained from an attached resource." in caplog.text
+        )
 
 
 # --- TestTypeValidation ---

--- a/tests/unit/test_log_proxy_consumer.py
+++ b/tests/unit/test_log_proxy_consumer.py
@@ -16,6 +16,7 @@ from charms.loki_k8s.v0 import loki_push_api
 from charms.loki_k8s.v0.loki_push_api import LogProxyConsumer
 from ops.charm import CharmBase
 from ops.framework import StoredState
+from ops.model import Container as OpsContainer
 from ops.pebble import PathError
 from ops.testing import Context
 from scenario import Container, Model, Relation, Resource, State
@@ -264,7 +265,6 @@ def test_valid_container_name_works(consumer_context, loki_container, promtail_c
     with consumer_context(consumer_context.on.start(), state) as mgr:
         charm = mgr.charm
         container = charm.log_proxy._get_container("loki")
-        from ops.model import Container as OpsContainer
         assert isinstance(container, OpsContainer)
 
 

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -121,7 +121,7 @@ def test_on_logging_relation_changed(provider_context):
 
 
 def test_on_logging_relation_created_and_broken(provider_context):
-    """Test that alert rules changed event is fired on relation broken."""
+    """Test that alert_rules_changed fires on relation changed, then departed and broken."""
     logging_relation = Relation(
         "logging",
         remote_app_name="promtail",
@@ -131,18 +131,25 @@ def test_on_logging_relation_created_and_broken(provider_context):
 
     state = State(leader=True, relations=[logging_relation])
 
-    # Run relation_changed first
+    # WHEN the remote populates its alert rules (relation_changed)
     with provider_context(
         provider_context.on.relation_changed(logging_relation), state
     ) as mgr:
-        state_after_changed = mgr.run()
+        state = mgr.run()
+        # THEN alert_rules_changed is emitted once
         assert mgr.charm._stored.event_count == 1
 
-    # For relation_broken, we need to use the relation from the output state
-    rel_from_state = state_after_changed.get_relation(logging_relation.id)
-    provider_context.run(
-        provider_context.on.relation_broken(rel_from_state), state_after_changed
+    # WHEN the relation is removed, juju fires relation_departed then relation_broken
+    rel = state.get_relation(logging_relation.id)
+    state = provider_context.run(
+        provider_context.on.relation_departed(rel, remote_unit=0), state
     )
+
+    rel = state.get_relation(logging_relation.id)
+    with provider_context(provider_context.on.relation_broken(rel), state) as mgr:
+        mgr.run()
+        # THEN alert_rules_changed has fired two more times (departed + broken)
+        assert mgr.charm._stored.event_count == 3
 
 
 def test_alerts(provider_context):


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
This PR is based on:
- https://github.com/canonical/loki-k8s-operator/pull/626

and each commit is labeled for the question it addresses. @lucabello You can revert specific commits as you see fit.

## Solution
<!-- A summary of the solution addressing the above issue -->

## Test migration review (Harness → Scenario)

During the migration the following items were reviewed. Each was either restored to match the original behaviour, left as-is where faithful, or skipped as too invasive.

### Coverage restorations

- **Q1 — `test_3_provider_units_related_scaled_down_to_0`:** Removed. The scale-to-0 half was a unit-level transition not representable in a stateless Scenario test; the remaining assertion duplicated other coverage. Belongs in integration tests.
- **Q2 — `test_reload_*` (4 tests):** Rewritten to drive a live charm and call the public `_reinitialize_alert_rules()` directly (as the original Harness tests did), restoring the "directory removed" case and dropping an inline duplicate charm class.
- **Q3 — `test_on_logging_relation_created_and_broken`:** Restored the dropped event-count assertion (1 → 3) by re-emitting `relation_changed → relation_departed → relation_broken` and threading `StoredState` through the output state.
- **Q4 — `test_fetch_promtail_from_attached_resource`:** Restored real resource handling via `State(resources=[Resource(...)])`, asserting the attach path and INFO log. (Scenario requires all declared resources present, so the original pre-attach "is False" assertion isn't representable and was dropped with a note.)
- **Q5 — `test_regular_relation_departed/broken_runs_before_pebble_ready`:** Restored both resilience/event-ordering tests. The "don't crash before pebble-ready" guard is expressed by `ctx.run` not raising, followed by a pebble-ready transition asserting `ActiveStatus`. (Impl-detail `MaintenanceStatus`-before assertion trimmed by choice.)
- **Q6 — `test_alert_rule_errors_appropriately_set_state`:** Restored all three phases — initial failure → `BlockedStatus`, sticky (stays blocked on next event), and recovery → `ActiveStatus`.
- **Q7 — `test_loki_starts_..._without_any_relations`:** Restored the dropped `service.is_running()` check via the output container's `service_statuses["loki"] == ServiceStatus.ACTIVE`.
- **Q8 — `test_on_upgrade_charm_endpoint_joined_event_fired_for_leader/follower`:** Restored the dropped second-event assertion (1 → 2) by threading state and re-emitting `relation_changed`.

### Faithful / no-change

- **Q9 — `test_on_logging_relation_changed_no_leader/no_unit`:** Left as smoke tests. The original Harness assertion was vacuous (`update_relation_data` always returns `None`); the migrated "should not raise" form is faithful.

### Skipped

- **Q10 — conftest fixture consolidation:** Skipped as too core a change (would have touched 7 files renaming the shared `context` fixture). Reverted.
- **Q12 — exception narrowing:** Skipped/reverted. Left `pytest.raises(Exception)` in `test_log_files_various_invalid_types` rather than narrowing to `UncaughtCharmError`.

### Cleanups / consistency

- **Q11 — de-mock config rendering:** Removed `ConfigBuilder.build` patches in `test_on_config_cannot_connect` (dead — charm returns before `build()`) and `test_on_config_can_connect` (a fidelity regression vs. the original). Tests now exercise the real `config_builder`.
- **Q13 — container alias:** Hoisted `from ops.model import Container as OpsContainer` to the module imports in `test_log_proxy_consumer.py`, removing an inline import caused by the `scenario.Container` name collision.
- **Q14 — reload fixture:** Stopped `reload_context` returning a `(Context, sandbox)` tuple; tests now depend on the `alert_rules_sandbox` fixture directly, removing awkward unpacking. (Scope limited to the reload tests.)
- **Q15 — version-mock consistency:** Added the `/usr/bin/loki -version` exec stub to conftest's `loki_container` so it matches the test-local fixture. The existing double-mock in the delayed-pebble tests was kept intentionally, mirroring the original Harness.

---

Want this trimmed to a shorter bullet list, or grouped differently (e.g. by file)?

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
