### PR TITLE
refactor: Jubilant tests

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -171,7 +171,8 @@ def get_alertmanager_alerts(
 
 def oci_image(charmcraft_file: str, image_name: str) -> str:
     """Find upstream source for a container image."""
-    metadata = yaml.safe_load(open(charmcraft_file).read())
+    with open(charmcraft_file) as file:
+        metadata = yaml.safe_load(file)
     resources = metadata.get("resources", {})
     if not resources:
         raise ValueError("No resources found")

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -141,8 +141,8 @@ def loki_alerts(juju: jubilant.Juju, app_name: str, unit_num: int = 0, retries: 
             ]
             if alerts:
                 break
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("Failed to fetch Loki alerts from %s: %s", url, e)
         retries -= 1
         time.sleep(2)
 
@@ -161,8 +161,8 @@ def get_alertmanager_alerts(
             alerts = json.loads(urllib.request.urlopen(url, data=None, timeout=2).read())
             if alerts:
                 break
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("Failed to fetch Alertmanager alerts from %s: %s", url, e)
         retries -= 1
         time.sleep(2)
 

--- a/tests/integration/test_alert_rules_fire.py
+++ b/tests/integration/test_alert_rules_fire.py
@@ -70,8 +70,8 @@ def test_loki_scales_up(juju: jubilant.Juju):
         loki_alerts(juju, "loki", unit_num=i) for i in range(3)
     ]
 
-    for unit_num, unit_alerts in enumerate(alerts_per_unit):
-        assert unit_alerts, f"no alerts fired in Loki on unit {unit_num} after triggering log-error"
+    for unit_alerts in alerts_per_unit:
+        assert unit_alerts, f"no alerts fired in Loki units after triggering log-error"
         assert all(
             key in alert["labels"].keys()
             for key in ["juju_application", "juju_model", "juju_model_uuid"]

--- a/tests/integration/test_alert_rules_fire.py
+++ b/tests/integration/test_alert_rules_fire.py
@@ -39,6 +39,7 @@ def test_alert_rules_do_fire(
     # Trigger a log message to fire an alert on
     juju.run(f"{tester_app_name}/0", "log-error", {"message": "Error logged!"})
     alerts = loki_alerts(juju, "loki")
+    assert alerts, "no alerts fired in Loki after triggering log-error"
     assert all(
         key in alert["labels"].keys()
         for key in ["juju_application", "juju_model", "juju_model_uuid"]
@@ -69,7 +70,8 @@ def test_loki_scales_up(juju: jubilant.Juju):
         loki_alerts(juju, "loki", unit_num=i) for i in range(3)
     ]
 
-    for unit_alerts in alerts_per_unit:
+    for unit_num, unit_alerts in enumerate(alerts_per_unit):
+        assert unit_alerts, f"no alerts fired in Loki on unit {unit_num} after triggering log-error"
         assert all(
             key in alert["labels"].keys()
             for key in ["juju_application", "juju_model", "juju_model_uuid"]

--- a/tests/integration/test_upgrade_charm_retains_alerts.py
+++ b/tests/integration/test_upgrade_charm_retains_alerts.py
@@ -53,6 +53,7 @@ def test_deploy_charms(
 def test_rule_files_are_retained_after_pod_upgraded(juju: jubilant.Juju, loki_charm, loki_resources):
     """Deploy from charmhub and then upgrade with the charm-under-test."""
     rules_before_upgrade = loki_rules(juju, app_name)
+    assert rules_before_upgrade, "no alert rules present in Loki before upgrade"
     logger.debug("upgrade deployed charm with local charm %s", loki_charm)
     juju.cli("refresh", app_name, f"--path={loki_charm}")
 


### PR DESCRIPTION
## Solution

**Strengthen alert assertions to avoid vacuous passes**
- `tests/integration/test_alert_rules_fire.py`: Added an explicit `assert alerts, "no alerts fired in Loki after triggering log-error"` before the label-key check. Previously the `all(... for alert in alerts)` check was vacuously `True` when no alerts had fired, so the test could pass without Loki ever producing an alert. The scale-up case (`test_loki_scales_up`) gained an equivalent non-empty guard.
- `tests/integration/test_upgrade_charm_retains_alerts.py`: Added `assert rules_before_upgrade, "no alert rules present in Loki before upgrade"` immediately after fetching the pre-upgrade rules. Without it, a `{} == {}` comparison would pass even if no rules were ever present, defeating the purpose of the retention test.

**Surface swallowed errors in alert-polling helpers**
- `tests/integration/helpers.py`: In `loki_alerts` and `get_alertmanager_alerts`, replaced the silent `except Exception: pass` with `except Exception as e: logger.debug(...)` (including the URL and error). Transient fetch failures are now visible in the logs instead of silently masquerading as "no alerts."

**Fix file-handle leak in `oci_image`**
- `tests/integration/helpers.py`: `oci_image` now reads `charmcraft.yaml` via a `with open(...) as file:` context manager instead of `open(charmcraft_file).read()`, so the file is closed deterministically. No behavior change.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
See CI runs

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
