### PR TITLE
fix: empty errors from relation data if there are no validation errors

### DIFF
--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -544,7 +544,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 26
+LIBPATCH = 27
 
 PYDEPS = ["cosl"]
 
@@ -1198,6 +1198,10 @@ class LokiPushApiProvider(Object):
                 if self._charm.unit.is_leader():
                     relation.data[self._charm.app]["event"] = json.dumps({"errors": errmsg})
                 continue
+            if self._charm.unit.is_leader():
+                event_data = json.loads(relation.data[self._charm.app].get("event", "{}"))
+                event_data.pop("errors", None)
+                relation.data[self._charm.app]["event"] = json.dumps(event_data)
 
             alerts[identifier] = alert_rules
 

--- a/tests/unit/test_alert_rule_filtering.py
+++ b/tests/unit/test_alert_rule_filtering.py
@@ -1,6 +1,7 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import dataclasses
 import json
 from unittest.mock import patch
 
@@ -89,6 +90,10 @@ INVALID_RELATION = Relation(
 )
 
 
+def mark_alert_rules_active(charm):
+    charm._stored.status["rules"] = ("active", "")
+
+
 def test_valid_relation_only(context, loki_container):
     # GIVEN one relation with only valid rules
     state_in = State(relations=[VALID_RELATION], containers=[loki_container], leader=True)
@@ -128,3 +133,37 @@ def test_valid_and_invalid_relations(context, loki_container):
     # THEN only valid relation rules are written and unit is blocked due to invalid relation
     assert _written_group_names(context, state_out) == {"valid-group"}
     assert isinstance(state_out.unit_status, BlockedStatus)
+
+
+def test_invalid_relation_becoming_valid_recovers_to_active(context, loki_container):
+    # GIVEN a relation with invalid rules has already blocked the charm
+    state_in = State(relations=[INVALID_RELATION], containers=[loki_container], leader=True)
+
+    with patch("charm.LokiOperatorCharm._check_alert_rules", return_value=None):
+        blocked_state = context.run(context.on.relation_changed(INVALID_RELATION), state_in)
+
+    assert isinstance(blocked_state.unit_status, BlockedStatus)
+
+    # WHEN the same relation updates its rules to become valid
+    relation_after_invalid = blocked_state.get_relation(INVALID_RELATION.id)
+    now_valid_relation = dataclasses.replace(
+        relation_after_invalid,
+        remote_app_data={
+            **relation_after_invalid.remote_app_data,
+            "alert_rules": VALID_RELATION.remote_app_data["alert_rules"],
+        },
+    )
+
+    with patch(
+        "charm.LokiOperatorCharm._check_alert_rules",
+        autospec=True,
+        side_effect=mark_alert_rules_active,
+    ):
+        recovered_state = context.run(
+            context.on.relation_changed(now_valid_relation),
+            dataclasses.replace(blocked_state, relations=[now_valid_relation]),
+        )
+
+    # THEN the previous invalid status is cleared and valid rules are written
+    assert _written_group_names(context, recovered_state) == {"valid-group"}
+    assert isinstance(recovered_state.unit_status, ActiveStatus)


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes #632.

## Solution
<!-- A summary of the solution addressing the above issue -->
When we process the alerts from a relation and validate them, we will pop `.events.errors` (safely) so that we remove the validation errors from before.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
Deploy this bundle:
```yaml
bundle: kubernetes
applications:
  cos-config:
    charm: cos-configuration-k8s
    channel: dev/edge
    revision: 103
    resources:
      git-sync-image: 36
    scale: 1
    options:
      git_branch: main
      git_repo: https://github.com/sinapah/cos-config
      loki_alert_rules_path: staging/loki
    constraints: arch=amd64
    storage:
      content-from-git: kubernetes,1,1024M
    trust: true
  loki:
    charm: loki-k8s
    channel: dev/edge
    revision: 230
    resources:
      loki-image: 105
      node-exporter-image: 4
    scale: 1
    constraints: arch=amd64
    storage:
      active-index-directory: kubernetes,1,1024M
      loki-chunks: kubernetes,1,1024M
    trust: true
relations:
- - cos-config:loki-config
  - loki:logging

```
Pack and refresh the charm with these changes.

Now, `juju config cos-config loki_alert_rules_path=loki_alert_rules`. This path contains only valid rules. The charm should become active after finishing the execution.
## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
