### PR TITLE
fix: catch `URLError` when downloading the Promtail binary (lib v0)

### DIFF
--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -458,7 +458,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
 from urllib import request
-from urllib.error import HTTPError
+from urllib.error import URLError
 
 import yaml
 from cosl import JujuTopology
@@ -485,7 +485,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 32
+LIBPATCH = 33
 
 PYDEPS = ["cosl"]
 
@@ -2332,7 +2332,7 @@ class LogProxyConsumer(ConsumerBase):
         if not self._is_promtail_installed(promtail_binaries[self._arch]):
             try:
                 self._obtain_promtail(promtail_binaries[self._arch])
-            except HTTPError as e:
+            except URLError as e:
                 msg = "Promtail binary couldn't be downloaded - {}".format(str(e))
                 logger.warning(msg)
                 self.on.promtail_digest_error.emit(msg)

--- a/tests/unit/test_log_proxy_consumer.py
+++ b/tests/unit/test_log_proxy_consumer.py
@@ -12,6 +12,7 @@ import unittest
 from pathlib import Path
 from tempfile import mkdtemp
 from unittest.mock import mock_open, patch
+from urllib.error import HTTPError, URLError
 
 from charms.loki_k8s.v0 import loki_push_api
 from charms.loki_k8s.v0.loki_push_api import LogProxyConsumer
@@ -262,6 +263,71 @@ class TestLogProxyConsumer(unittest.TestCase):
             self.assertTrue(
                 self.harness.charm.log_proxy._download_and_push_promtail_to_workload.called  # type: ignore
             )
+
+    @patch("charms.loki_k8s.v0.loki_push_api.LogProxyConsumer._is_promtail_installed")
+    @patch("charms.loki_k8s.v0.loki_push_api.LogProxyConsumer._obtain_promtail")
+    def test__setup_promtail_handles_url_error_on_download(self, mock_obtain, mock_is_installed):
+        # Regression test for https://github.com/canonical/loki-k8s-operator/issues/624
+
+        # GIVEN promtail is not yet installed and the download fails at the connection
+        # level (e.g. missing juju proxy configuration), which raises a bare URLError
+        # rather than an HTTPError
+        mock_is_installed.return_value = False
+        mock_obtain.side_effect = URLError(reason="[Errno 110] Connection timed out")
+
+        rel_id = self.harness.add_relation("log-proxy", "agent")
+        self.harness.add_relation_unit(rel_id, "agent/0")
+        self.harness.update_relation_data(
+            rel_id,
+            "agent",
+            {
+                "promtail_binary_zip_url": json.dumps(
+                    {self.harness.charm.log_proxy._arch: {**PROMTAIL_INFO, "url": "http://x"}}
+                )
+            },
+        )
+
+        events_before = self.harness.charm._stored.invalid_events
+
+        # WHEN promtail setup runs
+        self.harness.charm.log_proxy._setup_promtail()
+
+        # THEN the URLError is caught (the hook does not crash) and surfaced as a digest error
+        self.assertEqual(self.harness.charm._stored.invalid_events, events_before + 1)
+
+    @patch("charms.loki_k8s.v0.loki_push_api.LogProxyConsumer._is_promtail_installed")
+    @patch("charms.loki_k8s.v0.loki_push_api.LogProxyConsumer._obtain_promtail")
+    def test__setup_promtail_handles_http_error_on_download(self, mock_obtain, mock_is_installed):
+        # GIVEN promtail is not yet installed and the download fails with an HTTPError
+        # (a subclass of URLError), so the previously supported behaviour must keep working
+        mock_is_installed.return_value = False
+        mock_obtain.side_effect = HTTPError(
+            url="http://x",
+            code=404,
+            msg="not found",
+            fp=None,
+            hdrs=None,  # type: ignore
+        )
+
+        rel_id = self.harness.add_relation("log-proxy", "agent")
+        self.harness.add_relation_unit(rel_id, "agent/0")
+        self.harness.update_relation_data(
+            rel_id,
+            "agent",
+            {
+                "promtail_binary_zip_url": json.dumps(
+                    {self.harness.charm.log_proxy._arch: {**PROMTAIL_INFO, "url": "http://x"}}
+                )
+            },
+        )
+
+        events_before = self.harness.charm._stored.invalid_events
+
+        # WHEN promtail setup runs
+        self.harness.charm.log_proxy._setup_promtail()
+
+        # THEN the HTTPError is caught (the hook does not crash) and surfaced as a digest error
+        self.assertEqual(self.harness.charm._stored.invalid_events, events_before + 1)
 
     @patch("ops.model.Container.pull")
     def test__promtail_can_handle_missing_configuration(self, mock_pull):


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes [#624](https://github.com/canonical/loki-k8s-operator/issues/624).

In `loki_push_api` v0, when a charm using `LogProxyConsumer` runs behind a proxy and the Juju model is missing the proxy configuration (e.g. `juju-https-proxy`), downloading the Promtail binary fails with an uncaught `urllib.error.URLError` (connection timeout).
The unhandled exception bubbles up and crashes the charm hook (e.g. `*-pebble-ready`).

This was reported downstream in [mysql-operators#349](https://github.com/canonical/mysql-operators/issues/349), where the affected unit gets stuck in `maintenance` ("starting mysql") forever, with this traceback:

```
...
  File "/var/lib/juju/agents/unit-mysql-0/charm/lib/charms/loki_k8s/v0/loki_push_api.py", line 2002, in _obtain_promtail
    self._download_and_push_promtail_to_workload(promtail_info)
  File "/var/lib/juju/agents/unit-mysql-0/charm/lib/charms/loki_k8s/v0/loki_push_api.py", line 2146, in _download_and_push_promtail_to_workload
    with opener.open(promtail_info["url"]) as r:
  File "/usr/lib/python3.10/urllib/request.py", line 519, in open
    response = self._open(req, data)
  File "/usr/lib/python3.10/urllib/request.py", line 536, in _open
    result = self._call_chain(self.handle_open, protocol, protocol +
  File "/usr/lib/python3.10/urllib/request.py", line 496, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.10/urllib/request.py", line 1391, in https_open
    return self.do_open(http.client.HTTPSConnection, req,
  File "/usr/lib/python3.10/urllib/request.py", line 1351, in do_open
    raise URLError(err)
urllib.error.URLError: <urlopen error [Errno 110] Connection timed out>
```

## Solution
<!-- A summary of the solution addressing the above issue -->
In `LogProxyConsumer._setup_promtail`, broaden the caught exception from `HTTPError` to `URLError` so that connection-level failures (timeouts, DNS errors, missing proxy) are handled gracefully instead of crashing the hook. On failure, the consumer now logs a warning and emits `promtail_digest_error`, consistent with the existing behaviour for HTTP errors.

Changes in `lib/charms/loki_k8s/v0/loki_push_api.py`:
- `from urllib.error import HTTPError` -> `from urllib.error import URLError`
- `except HTTPError as e:` -> `except URLError as e:`
- Bumped `LIBPATCH` from `32` to `33`.

This aligns v0 with v1, which already catches `URLError`.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
In Python's `urllib`, the exception hierarchy is:

```
OSError
 └── urllib.error.URLError       # connection-level failures (timeout, DNS, no proxy, ...)
      └── urllib.error.HTTPError  # HTTP response errors (404, 500, ...)
```

`HTTPError` is a **subclass** of `URLError`. The previous code only caught `HTTPError`, so HTTP response errors were handled, but bare connection failures (which surface as `URLError`) were not. Catching `URLError` covers both cases without losing the previous behaviour.

`LogProxyConsumer`/Promtail is deprecated by Grafana in favour of `LokiPushApiConsumer`, but v0 is still consumed by charms in the field (e.g. mysql-k8s).

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
Two regression tests were added in `tests/unit/test_log_proxy_consumer.py`

- `test__setup_promtail_handles_url_error_on_download` — reproduces #624: a bare `URLError` raised during download must be caught (no crash) and surfaced as a digest error.
- `test__setup_promtail_handles_http_error_on_download` — ensures the previously supported  `HTTPError` path keeps working.

Run the unit tests:

```sh
tox -e unit -- tests/unit/test_log_proxy_consumer.py
```

To confirm this is a true regression test: with the old code (`except HTTPError`), the `URLError` test fails with the exact traceback from #624; with the fix it passes.

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
No action required for the Loki charm itself.

Charms that vendor the `loki_push_api` v0 library and use `LogProxyConsumer` should refresh the library to pick up the fix:

```sh
charmcraft fetch-lib charms.loki_k8s.v0.loki_push_api
```

Note: this change prevents the hook from crashing on a failed download; it does not download Promtail by itself. In proxied environments the Juju model should still be configured with the appropriate proxy settings (e.g. `juju-https-proxy`) for Promtail to be fetched successfully.
