### PR TITLE
fix: use platform.machine()

### DIFF
--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -485,7 +485,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 33
+LIBPATCH = 34
 
 PYDEPS = ["cosl"]
 
@@ -1812,7 +1812,7 @@ class LogProxyConsumer(ConsumerBase):
         self.insecure_skip_verify = insecure_skip_verify
 
         # architecture used for promtail binary
-        arch = platform.processor()
+        arch = platform.machine()
         self._arch = "amd64" if arch == "x86_64" else arch
 
         events = self._charm.on[relation_name]

--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -544,7 +544,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 27
+LIBPATCH = 28
 
 PYDEPS = ["cosl"]
 

--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -544,7 +544,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 26
+LIBPATCH = 27
 
 PYDEPS = ["cosl"]
 
@@ -1700,7 +1700,7 @@ class LogProxyConsumer(ConsumerBase):
         self._promtails_ports = self._generate_promtails_ports(logs_scheme)
 
         # architecture used for promtail binary
-        arch = platform.processor()
+        arch = platform.machine()
         if arch in ["x86_64", "amd64"]:
             self._arch = "amd64"
         elif arch in ["aarch64", "arm64", "armv8b", "armv8l"]:


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes #636.
We have to do this to unblock charms that rely on Promtail (outdated, but we should do it for safety and good citizenship).

## Solution
<!-- A summary of the solution addressing the above issue -->
We use `platform.machine()` instead of `platform.processor()`.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
This PR will unblock https://github.com/canonical/prometheus-pushgateway-k8s-operator/pull/56

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
