### PR TITLE
chore: bump base of tester charms

### DIFF
--- a/tests/integration/log-forwarder-tester/charmcraft.yaml
+++ b/tests/integration/log-forwarder-tester/charmcraft.yaml
@@ -6,7 +6,7 @@ summary: Fake log generator
 description: Fake log generator
 
 platforms:
-  ubuntu@24.04:amd64:
+  ubuntu@26.04:amd64:
 
 parts:
   charm:

--- a/tests/integration/log-proxy-tester/charmcraft.yaml
+++ b/tests/integration/log-proxy-tester/charmcraft.yaml
@@ -6,7 +6,7 @@ summary: Fake log generator
 description: Fake log generator
 
 platforms:
-  ubuntu@24.04:amd64:
+  ubuntu@26.04:amd64:
 
 parts:
   charm:


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes #639. Note that tester charms themselves are something we are (or should be trying to :upside_down_face:) phase out because of their "unmaintainability". Until that happens, we still rely on them to assert correct functionality.

We should ensure their bases stay up to date with the main charm to avoid issues such as #637. 

## Solution
<!-- A summary of the solution addressing the above issue -->
Bump the bases of the two tester charms in this repo.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
